### PR TITLE
Add rake task support

### DIFF
--- a/activerecord-cockroachdb-adapter.gemspec
+++ b/activerecord-cockroachdb-adapter.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "activerecord-cockroachdb-adapter"
-  spec.version       = "0.1.0"
+  spec.version       = "0.1.1"
   spec.licenses      = ["Apache-2.0"]
   spec.authors       = ["Cockroach Labs"]
   spec.email         = ["cockroach-db@googlegroups.com"]

--- a/lib/active_record/connection_adapters/cockroachdb/database_tasks.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/database_tasks.rb
@@ -1,0 +1,19 @@
+require "active_record/base"
+
+module ActiveRecord
+  module ConnectionAdapters
+    module CockroachDB
+      class DatabaseTasks < ActiveRecord::Tasks::PostgreSQLDatabaseTasks
+        def structure_dump(filename, extra_flags=nil)
+          raise "db:structure:dump is unimplemented. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/2"
+        end
+
+        def structure_load(filename, extra_flags=nil)
+          raise "db:structure:load is unimplemented. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/2"
+        end
+      end
+    end
+  end
+end
+
+ActiveRecord::Tasks::DatabaseTasks.register_task(/cockroachdb/, ActiveRecord::ConnectionAdapters::CockroachDB::DatabaseTasks)

--- a/lib/activerecord-cockroachdb-adapter.rb
+++ b/lib/activerecord-cockroachdb-adapter.rb
@@ -1,0 +1,11 @@
+if defined?(Rails)
+  module ActiveRecord
+    module ConnectionAdapters
+      class CockroachDBRailtie < ::Rails::Railtie
+        rake_tasks do
+          load "active_record/connection_adapters/cockroachdb/database_tasks.rb"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This just delegates to the Postgres rake task implementations. This
works fine except for db:structure:dump/load, which delegate to the
`pg_dump` binary. Those raise exceptions for now.