### PR TITLE
WIP Uuid function fix

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_definitions.rb
@@ -37,6 +37,10 @@ module ActiveRecord
           super
         end
       end
+
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        include ColumnMethods
+      end
     end
   end
 end

--- a/lib/active_record/connection_adapters/cockroachdb/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_definitions.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module CockroachDB
+      module ColumnMethods
+        # Defines the primary key field.
+        # Use of the native CockroachDB UUID type is supported, and can be used
+        # by defining your tables as such:
+        #
+        #   create_table :stuffs, id: :uuid do |t|
+        #     t.string :content
+        #     t.timestamps
+        #   end
+        #
+        # By default, this will use the +uuid_v4()::UUID+ as defined in
+        # https://www.cockroachlabs.com/docs/v1.1/uuid.html, which is equivalent of :
+        #
+        #   create_table :stuffs, id: false do |t|
+        #     t.primary_key :id, :uuid, default: "uuid_v4()::UUID"
+        #     t.uuid :foo_id
+        #     t.timestamps
+        #   end
+        #
+        # You may also pass a custom stored procedure that returns a UUID or use a
+        # different UUID generation function from another library.
+        #
+        # Note that setting the UUID primary key default value to +nil+ will
+        # require you to assure that you always provide a UUID value before saving
+        # a record (as primary keys cannot be +nil+). This might be done via the
+        # +SecureRandom.uuid+ method and a +before_save+ callback, for instance.
+        def primary_key(name, type = :primary_key, **options)
+          if type == :uuid
+            options[:default] = options.fetch(:default, "uuid_v4()::UUID")
+          end
+
+          super
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related : https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/12

An attempt to set the uuid function name properly for AR to use when generating the SQL query; unfortunately I am not familiar enough to attach those bits in the adapter to get it to work fine.
It's probably not missing much, any direction into where to look would be appreciated.