### PR TITLE
fix: schema load failing with int to string conversion error

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
@@ -52,6 +52,49 @@ module ActiveRecord
             query_value("SELECT setval(#{quote(quoted_sequence)}, #{max_pk ? max_pk : minvalue})", "SCHEMA")
           end
         end
+
+        # copied from ConnectionAdapters::SchemaStatements
+        #
+        # modified insert into statement to always wrap the version value into single quotes for cockroachdb.
+        def assume_migrated_upto_version(version, migrations_paths)
+          migrations_paths = Array(migrations_paths)
+          version = version.to_i
+
+          migrated = ActiveRecord::SchemaMigration.all_versions.map(&:to_i)
+          versions = migration_context.migration_files.map do |file|
+            migration_context.parse_migration_filename(file).first.to_i
+          end
+
+          unless migrated.include?(version)
+            execute insert_versions_sql(version)
+          end
+
+          inserting = (versions - migrated).select { |v| v < version }
+          if inserting.any?
+            if (duplicate = inserting.detect { |v| inserting.count(v) > 1 })
+              raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
+            end
+            if supports_multi_insert?
+              execute insert_versions_sql(inserting)
+            else
+              inserting.each do |v|
+                execute insert_versions_sql(v)
+              end
+            end
+          end
+        end
+
+        def insert_versions_sql(versions)
+          sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
+          if versions.is_a?(Array)
+            sql = "INSERT INTO #{sm_table} (version) VALUES\n".dup
+            sql << versions.map { |v| "('#{quote(v)}')" }.join(",\n")
+            sql << ";\n\n"
+            sql
+          else
+            "INSERT INTO #{sm_table} (version) VALUES ('#{quote(versions)}');"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
I extracted the monkeypatch described [here](https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/24#issuecomment-386791078) into the existing CockrachDb::SchemaStatement module. 

This should solve #24 when executing `rails db:schema:load` or similar commands that involve schema.rb