### PR TITLE
gemspec: Remove pg pinning

### DIFF
--- a/activerecord-cockroachdb-adapter.gemspec
+++ b/activerecord-cockroachdb-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/cockroachdb/activerecord-cockroachdb-adapter"
 
   spec.add_dependency "activerecord", "~> 5.2"
-  spec.add_dependency "pg", ">= 0.20", "< 0.22"
+  spec.add_dependency "pg"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
It isn't necessary to pin this gem anymore. The related commit
29175527605d58fd7f84b6cc2beb5096be0256ba from before already switches to
the new constant layout.