### PR TITLE
Run ActiveRecord tests from source instead of a fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "rails"]
-	path = rails
-	url = https://github.com/lego/ruby-on-rails.git

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,32 @@
+require 'openssl'
 source 'https://rubygems.org'
-
-# gem 'activerecord', git: 'https://github.com/lego/ruby-on-rails.git'
-
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
-# Specify your gem's dependencies in activerecord-cockroachdb-adapter.gemspec
 gemspec
 
-# We need a newish Rake since Active Job sets its test tasks' descriptions.
-gem "rake", ">= 11.1"
+if ENV['RAILS_SOURCE']
+  gemspec path: ENV['RAILS_SOURCE']
+else
+  def get_version_from_gemspec
+    require 'net/http'
+    require 'yaml'
+    spec = eval(File.read('activerecord-cockroachdb-adapter.gemspec'))
+    ver = spec.dependencies.detect{ |d|d.name == 'activerecord' }.requirement.requirements.first.last.version
+    major, minor, tiny, pre = ver.split('.')
+
+    if !pre
+      uri = URI.parse "https://rubygems.org/api/v1/versions/activerecord.yaml"
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      YAML.load(http.request(Net::HTTP::Get.new(uri.request_uri)).body).select do |data|
+        a, b, c = data['number'].split('.')
+        !data['prerelease'] && major == a && (minor.nil? || minor == b)
+      end.first['number']
+    else
+      ver
+    end
+  end
+
+  # Get Rails from source beacause the gem doesn't include tests
+  version = ENV['RAILS_VERSION'] || get_version_from_gemspec
+  gem 'rails', git: "https://github.com/rails/rails.git", tag: "v#{version}"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -8,24 +8,45 @@ if ENV['RAILS_SOURCE']
   gemspec path: ENV['RAILS_SOURCE']
 else
   def get_version_from_gemspec
+    gemspec = eval(File.read('activerecord-cockroachdb-adapter.gemspec'))
+
+    gem_version = gemspec.dependencies.
+      find { |dep| dep.name == 'activerecord' }.
+      requirement.
+      requirements.
+      first.
+      last
+
+    major, minor, tiny, pre = gem_version.segments
+
+    if pre
+      gem_version.to_s
+    else
+      find_latest_matching_version(major, minor)
+    end
+  end
+
+  def find_latest_matching_version(gemspec_major, gemspec_minor)
+    all_activerecord_versions.
+      reject { |version| version["prerelease"] }.
+      map { |version| version["number"].split(".").map(&:to_i) }.
+      find { |major, minor|
+        major == gemspec_major && (minor == gemspec_minor || gemspec_minor.nil?)
+      }.join(".")
+  end
+
+  def all_activerecord_versions
     require 'net/http'
     require 'yaml'
-    spec = eval(File.read('activerecord-cockroachdb-adapter.gemspec'))
-    ver = spec.dependencies.detect{ |d|d.name == 'activerecord' }.requirement.requirements.first.last.version
-    major, minor, tiny, pre = ver.split('.')
 
-    if !pre
-      uri = URI.parse "https://rubygems.org/api/v1/versions/activerecord.yaml"
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      YAML.load(http.request(Net::HTTP::Get.new(uri.request_uri)).body).select do |data|
-        a, b, c = data['number'].split('.')
-        !data['prerelease'] && major == a && (minor.nil? || minor == b)
-      end.first['number']
-    else
-      ver
-    end
+    uri = URI.parse "https://rubygems.org/api/v1/versions/activerecord.yaml"
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    YAML.load(
+      http.request(Net::HTTP::Get.new(uri.request_uri)).body
+    )
   end
 
   # Get Rails from source beacause the gem doesn't include tests

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ require 'openssl'
 source 'https://rubygems.org'
 gemspec
 
+gem 'bcrypt' # used by the ActiveRecord test suite
+
 if ENV['RAILS_SOURCE']
   gemspec path: ENV['RAILS_SOURCE']
 else
@@ -29,4 +31,9 @@ else
   # Get Rails from source beacause the gem doesn't include tests
   version = ENV['RAILS_VERSION'] || get_version_from_gemspec
   gem 'rails', git: "https://github.com/rails/rails.git", tag: "v#{version}"
+end
+
+group :development do
+  gem "byebug"
+  gem "mocha" # used by the ActiveRecord test suite
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,22 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+require_relative 'test/support/paths_cockroachdb'
+require_relative 'test/support/rake_helpers'
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList['test/**/*_test.rb']
+task test: ["test:cockroachdb"]
+task default: [:test]
+
+namespace :test do
+  Rake::TestTask.new("cockroachdb") do |t|
+    t.libs = ARTest::CockroachDB.test_load_paths
+    t.test_files = test_files
+    t.warning = !!ENV["WARNING"]
+    t.verbose = false
+  end
+
+  task "cockroachdb:env" do
+    ENV["ARCONN"] = "cockroachdb"
+  end
 end
 
-task :default => :test
+task 'test:cockroachdb' => 'test:cockroachdb:env'

--- a/activerecord-cockroachdb-adapter.gemspec
+++ b/activerecord-cockroachdb-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/cockroachdb/activerecord-cockroachdb-adapter"
 
   spec.add_dependency "activerecord", "~> 5.2"
-  spec.add_dependency "pg", ">= 0.20", "< 0.22"
+  spec.add_dependency "pg", ">= 0.20"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
@@ -31,8 +31,4 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/test/config.yml
+++ b/test/config.yml
@@ -1,0 +1,18 @@
+connections:
+  cockroachdb:
+    arunit:
+      min_messages: warning
+      host: localhost
+      port: 26257
+      user: root
+    arunit_without_prepared_statements:
+      min_messages: warning
+      prepared_statements: false
+      host: localhost
+      port: 26257
+      user: root
+    arunit2:
+      min_messages: warning
+      host: localhost
+      port: 26257
+      user: root

--- a/test/support/paths_cockroachdb.rb
+++ b/test/support/paths_cockroachdb.rb
@@ -1,0 +1,46 @@
+module ARTest
+  module CockroachDB
+
+    extend self
+
+    def root_cockroachdb
+      File.expand_path File.join(File.dirname(__FILE__), '..', '..')
+    end
+
+    def test_root_cockroachdb
+      File.join root_cockroachdb, 'test'
+    end
+
+    def root_activerecord
+      File.join Gem.loaded_specs['rails'].full_gem_path, 'activerecord'
+    end
+
+    def root_activerecord_lib
+      File.join root_activerecord, 'lib'
+    end
+
+    def root_activerecord_test
+      File.join root_activerecord, 'test'
+    end
+
+    def test_load_paths
+      ['lib', 'test', root_activerecord_lib, root_activerecord_test]
+    end
+
+    def add_to_load_paths!
+      test_load_paths.each { |p| $LOAD_PATH.unshift(p) unless $LOAD_PATH.include?(p) }
+    end
+
+    def arconfig_file
+      File.join test_root_cockroachdb, 'config.yml'
+    end
+
+    def arconfig_file_env!
+      ENV['ARCONFIG'] = arconfig_file
+    end
+
+  end
+end
+
+ARTest::CockroachDB.add_to_load_paths!
+ARTest::CockroachDB.arconfig_file_env!

--- a/test/support/rake_helpers.rb
+++ b/test/support/rake_helpers.rb
@@ -1,0 +1,20 @@
+def env_ar_test_files
+  return unless ENV['TEST_FILES_AR'] && !ENV['TEST_FILES_AR'].empty?
+
+  @env_ar_test_files ||= ENV['TEST_FILES_AR'].
+    split(',').
+    map { |file| File.join ARTest::CockroachDB.root_activerecord, file.strip }.
+    sort
+end
+
+def ar_cases
+  @ar_cases ||= Dir.
+    glob("#{ARTest::CockroachDB.root_activerecord}/test/cases/**/*_test.rb").
+    reject{ |x| x =~ /\/adapters\/mysql2\// }.
+    reject{ |x| x =~ /\/adapters\/sqlite3\// }.
+    sort
+end
+
+def test_files
+  env_ar_test_files || ar_cases
+end


### PR DESCRIPTION
Before this change, the ActiveRecord test suite was being run from a forked and modified version of Rails. This has worked well, but it's hard to maintain long term. As Rails changes, it'll get harder and harder to update the forked copy of Rails.

In this PR, I borrowed the [setup used by the ActiveRecord SQL Server Adapter](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/0a0ee519a423ac9a6a142834616a8e1a8252c7e7/RUNNING_UNIT_TESTS.md). Now we'll be able to run the ActiveRecord test suite against the Rails version specified by the adapter (currently Rails 5.2) by running `bundle exec rake test`. We'll also have the option to run against a local copy of Rails with `RAILS_SOURCE="path/to/local_copy" bundle exec rake test`. This will come in handy when debugging/prototyping. Finally, we can run specific ActiveRecord tests with `TEST_FILES_AR="path/to/test.rb,path/to/another_test.rb" bundle exec rake test`.

I updated the docs with this new setup and removed the Rails git submodule.