### PR TITLE
Ignore index errors via an environment variable

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
@@ -5,6 +5,17 @@ module ActiveRecord
     module CockroachDB
       module SchemaStatements
         include ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
+
+        def add_index(table_name, column_name, options = {})
+          super
+        rescue ActiveRecord::StatementInvalid => error
+          if debugging? && error.cause.class == PG::FeatureNotSupported
+            warn "#{error}\n\nThis error will be ignored and the index will not be created.\n\n"
+          else
+            raise error
+          end
+        end
+
         # NOTE(joey): This was ripped from PostgresSQL::SchemaStatements, with a
         # slight modification to change setval(string, int, bool) to just
         # setval(string, int) for CockroachDB compatbility.

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -36,6 +36,9 @@ module ActiveRecord
       include CockroachDB::SchemaStatements
       include CockroachDB::ReferentialIntegrity
 
+      def debugging?
+        !!ENV["DEBUG_COCKROACHDB_ADAPTER"]
+      end
 
       # Note that in the migration from ActiveRecord 5.0 to 5.1, the
       # `extract_schema_qualified_name` method was aliased in the PostgreSQLAdapter.


### PR DESCRIPTION
 When `DEBUG_COCKROACHDB_ADAPTER` is set, errors inserting partial or computed indexes will be logged and ignored. This lets us do things like load the ActiveRecord test suite schema without having to make changes to it.

Without `DEBUG_COCKROACHDB_ADAPTER`, running an AR test (via https://github.com/cockroachdb/activerecord-cockroachdb-adapter/pull/38) fails as it did before:

```
› bundle exec rake test TEST_FILES_AR="test/cases/associations_test.rb"                            
Using cockroachdb
Traceback (most recent call last):
 …
/Users/alimi/.rvm/gems/ruby-2.5.3/bundler/gems/rails-56f45bedd617/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `exec': PG::FeatureNotSupported: ERROR:  at or near "(": syntax error: unimplemented: this syntax (ActiveRecord::StatementInvalid)
DETAIL:  source SQL:
CREATE  INDEX  "company_partial_index" ON "companies"  ("firm_id", "type") WHERE (rating > 10)
                                                                                 ^
HINT:  You have attempted to use a feature that is not yet implemented.
See: https://github.com/cockroachdb/cockroach/issues/9683
: CREATE  INDEX  "company_partial_index" ON "companies"  ("firm_id", "type") WHERE (rating > 10)
rake aborted!
Command failed with status (1)
/Users/alimi/.rvm/gems/ruby-2.5.3/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/Users/alimi/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `eval'
/Users/alimi/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => test => test:cockroachdb
(See full trace by running task with --trace)
```

With `DEBUG_COCKROACHDB_ADAPTER` set, the error is ignored.

```
› DEBUG_COCKROACHDB_ADAPTER=1 bundle exec rake test TEST_FILES_AR="test/cases/associations_test.rb"
Using cockroachdb
PG::FeatureNotSupported: ERROR:  at or near "(": syntax error: unimplemented: this syntax
DETAIL:  source SQL:
CREATE  INDEX  "company_partial_index" ON "companies"  ("firm_id", "type") WHERE (rating > 10)
                                                                                 ^
HINT:  You have attempted to use a feature that is not yet implemented.
See: https://github.com/cockroachdb/cockroach/issues/9683
: CREATE  INDEX  "company_partial_index" ON "companies"  ("firm_id", "type") WHERE (rating > 10)

This error will be ignored and the index will not be created.
…
```

Down the road, `DEBUG_COCKROACHDB_ADAPTER` can be used when we would like to ignore other errors.