### PR TITLE
Retry transactions that fail from serialization errors 

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb/database_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/database_statements.rb
@@ -1,0 +1,21 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module CockroachDB
+      module DatabaseStatements
+        # Since CockroachDB will run all transactions with serializable isolation,
+        # READ UNCOMMITTED, READ COMMITTED, and REPEATABLE READ are all aliases
+        # for SERIALIZABLE. This lets the adapter support all isolation levels,
+        # but READ UNCOMMITTED has been removed from this list because the
+        # ActiveRecord transaction isolation test fails for READ UNCOMMITTED.
+        # See https://www.cockroachlabs.com/docs/v19.2/transactions.html#isolation-levels
+        def transaction_isolation_levels
+          {
+            read_committed:   "READ COMMITTED",
+            repeatable_read:  "REPEATABLE READ",
+            serializable:     "SERIALIZABLE"
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/cockroachdb/transaction_manager.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/transaction_manager.rb
@@ -15,7 +15,7 @@ module ActiveRecord
           raise if attempts >= @connection.max_transaction_retries
 
           attempts += 1
-          sleep_seconds = (((2 ** attempts) * 100) + rand( 100 - 1 ) + 1) / 1000.0
+          sleep_seconds = (2 ** attempts + rand) / 10
           sleep(sleep_seconds)
           within_new_transaction(options.merge(attempts: attempts)) { yield }
         end

--- a/lib/active_record/connection_adapters/cockroachdb/transaction_manager.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/transaction_manager.rb
@@ -1,25 +1,23 @@
 # frozen_string_literal: true
 
-require 'active_record/connection_adapters/abstract/transaction'
-
 module ActiveRecord
   module ConnectionAdapters
-
-    # NOTE(joey): This is a very sad monkey patch. Unfortunately, it is
-    # required in order to prevent doing more than 2 nested transactions
-    # while still allowing a single nested transaction. This is because
-    # CockroachDB only supports a single savepoint at the beginning of a
-    # transaction. Allowing this works for the common case of testing.
     module CockroachDB
       module TransactionManagerMonkeyPatch
-        def begin_transaction(options={})
-          @connection.lock.synchronize do
-            # If the transaction nesting is already 2 deep, raise an error.
-            if @connection.adapter_name == "CockroachDB" && @stack.is_a?(ActiveRecord::ConnectionAdapters::SavepointTransaction)
-              raise(ArgumentError, "cannot nest more than 1 transaction at a time. this is a CockroachDB limitation")
-            end
-          end
-          super(options)
+        # Capture ActiveRecord::SerializationFailure errors caused by
+        # transactions that fail due to serialization errors. Failed
+        # transactions will be retried until they pass or the max retry limit is
+        # exceeded.
+        def within_new_transaction(options = {})
+          attempts = options.fetch(:attempts, 0)
+          super
+        rescue ActiveRecord::SerializationFailure => error
+          raise if attempts >= @connection.max_transaction_retries
+
+          attempts += 1
+          sleep_seconds = (((2 ** attempts) * 100) + rand( 100 - 1 ) + 1) / 1000.0
+          sleep(sleep_seconds)
+          within_new_transaction(options.merge(attempts: attempts)) { yield }
         end
       end
     end

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -3,6 +3,7 @@ require "active_record/connection_adapters/postgresql/schema_statements"
 require "active_record/connection_adapters/cockroachdb/schema_statements"
 require "active_record/connection_adapters/cockroachdb/referential_integrity"
 require "active_record/connection_adapters/cockroachdb/transaction_manager"
+require "active_record/connection_adapters/cockroachdb/database_statements"
 
 module ActiveRecord
   module ConnectionHandling
@@ -35,6 +36,7 @@ module ActiveRecord
 
       include CockroachDB::SchemaStatements
       include CockroachDB::ReferentialIntegrity
+      include CockroachDB::DatabaseStatements
 
       def debugging?
         !!ENV["DEBUG_COCKROACHDB_ADAPTER"]
@@ -108,17 +110,6 @@ module ActiveRecord
       def supports_virtual_columns?
         # See cockroachdb/cockroach#20882.
         false
-      end
-
-      def transaction_isolation_levels
-        {
-          # Explicitly prevent READ UNCOMMITTED from being used. This
-          # was due to the READ UNCOMMITTED test failing.
-          # read_uncommitted: "READ UNCOMMITTED",
-          read_committed:   "READ COMMITTED",
-          repeatable_read:  "REPEATABLE READ",
-          serializable:     "SERIALIZABLE"
-        }
       end
 
       def primary_keys(table_name)

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -40,6 +40,10 @@ module ActiveRecord
         !!ENV["DEBUG_COCKROACHDB_ADAPTER"]
       end
 
+      def max_transaction_retries
+        @max_transaction_retries ||= @config.fetch(:max_transaction_retries, 3)
+      end
+
       # Note that in the migration from ActiveRecord 5.0 to 5.1, the
       # `extract_schema_qualified_name` method was aliased in the PostgreSQLAdapter.
       # To ensure backward compatibility with both <5.1 and 5.1, we rename it here
@@ -106,11 +110,6 @@ module ActiveRecord
         false
       end
 
-      def supports_savepoints?
-        # See cockroachdb/cockroach#10735.
-        false
-      end
-
       def transaction_isolation_levels
         {
           # Explicitly prevent READ UNCOMMITTED from being used. This
@@ -121,16 +120,6 @@ module ActiveRecord
           serializable:     "SERIALIZABLE"
         }
       end
-
-
-      # Sadly, we can only do savepoints at the beginning of
-      # transactions. This means that we cannot use them for most cases
-      # of transaction, so we just pretend they're usable.
-      def create_savepoint(name = "COCKROACH_RESTART"); end
-
-      def exec_rollback_to_savepoint(name = "COCKROACH_RESTART"); end
-
-      def release_savepoint(name = "COCKROACH_RESTART"); end
 
       def primary_keys(table_name)
           name = Utils.extract_schema_qualified_name(table_name.to_s)


### PR DESCRIPTION
ActiveRecord makes heavy use of savepoints to support nested transactions. That was disabled in the adapter because CockroachDB didn't support nested savepoints, but as of v20.1 it does 🎉

Instead of disabling nested transactions, the adapter can now retry transactions that error due to serialization errors. Since [ActiveRecord will rollback these erroring transactions](https://github.com/rails/rails/blob/ac30e389ecfa0e26e3d44c1eda8488ddf63b3ecc/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L237-L245), the adapter only needs to manage the number of retries.

The number of retries is configurable. Users will be able set it in `config/database.yml` like

```yml
  development:
    <<: *default
    database: app_development
    max_transaction_retries: 5
```

The current default retries of 3 was an arbitrary choice so lemme know if we should change it to something else.

I also moved `transaction_isolation_levels` to a new module, `CockroachDB::DatabaseStatements`. This will keep the adapter more in line with the other ActiveRecord adapters, and it'll be easier find what's been changed.