### PR TITLE
Remove supports_pg_crypto_uuid?

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -68,10 +68,6 @@ module ActiveRecord
         false
       end
 
-      def supports_pg_crypto_uuid?
-        false
-      end
-
       def supports_partial_index?
         # See cockroachdb/cockroach#9683
         false


### PR DESCRIPTION
This method doesn't exist in Rails, and it's nowhere to be found in the old Rails fork/git submodule.