### PR TITLE
Remove overridden assume_migrated_upto_version

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb/quoting.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/quoting.rb
@@ -1,0 +1,28 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module CockroachDB
+      module Quoting
+        private
+
+        # CockroachDB does not allow inserting integer values into string
+        # columns, but ActiveRecord expects this to work. CockroachDB will
+        # however allow inserting string values into integer columns. It will
+        # try to parse string values and convert them to integers so they can be
+        # inserted in integer columns.
+        #
+        # We take advantage of this behavior here by forcing numeric values to
+        # always be strings. Then, we won't have to make any additional changes
+        # to ActiveRecord to support inserting integer values into string
+        # columns.
+        def _quote(value)
+          case value
+          when Numeric
+            "'#{quote_string(value.to_s)}'"
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
@@ -63,49 +63,6 @@ module ActiveRecord
             query_value("SELECT setval(#{quote(quoted_sequence)}, #{max_pk ? max_pk : minvalue})", "SCHEMA")
           end
         end
-
-        # copied from ConnectionAdapters::SchemaStatements
-        #
-        # modified insert into statement to always wrap the version value into single quotes for cockroachdb.
-        def assume_migrated_upto_version(version, migrations_paths)
-          migrations_paths = Array(migrations_paths)
-          version = version.to_i
-
-          migrated = ActiveRecord::SchemaMigration.all_versions.map(&:to_i)
-          versions = migration_context.migration_files.map do |file|
-            migration_context.parse_migration_filename(file).first.to_i
-          end
-
-          unless migrated.include?(version)
-            execute insert_versions_sql(version)
-          end
-
-          inserting = (versions - migrated).select { |v| v < version }
-          if inserting.any?
-            if (duplicate = inserting.detect { |v| inserting.count(v) > 1 })
-              raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
-            end
-            if supports_multi_insert?
-              execute insert_versions_sql(inserting)
-            else
-              inserting.each do |v|
-                execute insert_versions_sql(v)
-              end
-            end
-          end
-        end
-
-        def insert_versions_sql(versions)
-          sm_table = quote_table_name(ActiveRecord::SchemaMigration.table_name)
-          if versions.is_a?(Array)
-            sql = "INSERT INTO #{sm_table} (version) VALUES\n".dup
-            sql << versions.map { |v| "('#{quote(v)}')" }.join(",\n")
-            sql << ";\n\n"
-            sql
-          else
-            "INSERT INTO #{sm_table} (version) VALUES ('#{quote(versions)}');"
-          end
-        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -4,6 +4,7 @@ require "active_record/connection_adapters/cockroachdb/schema_statements"
 require "active_record/connection_adapters/cockroachdb/referential_integrity"
 require "active_record/connection_adapters/cockroachdb/transaction_manager"
 require "active_record/connection_adapters/cockroachdb/database_statements"
+require "active_record/connection_adapters/cockroachdb/quoting"
 
 module ActiveRecord
   module ConnectionHandling
@@ -37,6 +38,7 @@ module ActiveRecord
       include CockroachDB::SchemaStatements
       include CockroachDB::ReferentialIntegrity
       include CockroachDB::DatabaseStatements
+      include CockroachDB::Quoting
 
       def debugging?
         !!ENV["DEBUG_COCKROACHDB_ADAPTER"]


### PR DESCRIPTION
Instead of overridding `assume_migrated_upto_version` to covert an integer to a string for an insert into a string column, we can customize `_quote` so numeric values are always treated as strings. If a numeric value is being inserted into an integer column, CockroachDB can parse the string and convert it to an integer. This allows for a smaller change that will be easier to maintain.