### PR TITLE
Skip PGChangeSchemaTest

### DIFF
--- a/test/excludes/ActiveRecord/Migration/PGChangeSchemaTest.rb
+++ b/test/excludes/ActiveRecord/Migration/PGChangeSchemaTest.rb
@@ -1,0 +1,3 @@
+exclude :test_change_string_to_date, "Changing column data types is not supported in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/9851."
+exclude :test_change_type_with_symbol, "Changing column data types is not supported in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/9851."
+exclude :test_change_type_with_array, "Changing column data types is not supported in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/9851."


### PR DESCRIPTION
Skip the PGChangeSchemaTest test as changing column data types is not supported. See https://github.com/cockroachdb/cockroach/issues/9851.