### PR TITLE
Skip PostgreSQL composite tests

### DIFF
--- a/test/excludes/PostgresqlCompositeTest.rb
+++ b/test/excludes/PostgresqlCompositeTest.rb
@@ -1,0 +1,2 @@
+exclude :test_column, "Composite types are not supported in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/27792"
+exclude :test_composite_mapping, "Composite types are not supported in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/27792"

--- a/test/excludes/PostgresqlCompositeWithCustomOIDTest.rb
+++ b/test/excludes/PostgresqlCompositeWithCustomOIDTest.rb
@@ -1,0 +1,2 @@
+exclude :test_column, "Composite types are not supported in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/27792"
+exclude :test_composite_mapping, "Composite types are not supported in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/27792"


### PR DESCRIPTION
Composite types are not supported by CockroachDB. See https://github.com/cockroachdb/cockroach/issues/27792.