### PR TITLE
Replace Postgresql serial tests

### DIFF
--- a/test/cases/adapters/postgresql/serial_test.rb
+++ b/test/cases/adapters/postgresql/serial_test.rb
@@ -1,0 +1,200 @@
+require "cases/helper_cockroachdb"
+
+# Load dependencies from ActiveRecord test suite
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+module CockroachDB
+  class PostgresqlSerialTest < ActiveRecord::PostgreSQLTestCase
+    include SchemaDumpingHelper
+
+    class PostgresqlSerial < ActiveRecord::Base; end
+
+    setup do
+      @connection = ActiveRecord::Base.connection
+      @connection.create_table "postgresql_serials", force: true do |t|
+        t.serial :seq
+
+        # Instead of creating this column with a sequence default, we'll create
+        # it with a unique_rowid() default. This better matches the behavior in
+        # CockroachDB.
+        t.integer :serials_id, default: -> { "unique_rowid()" }
+      end
+    end
+
+    teardown do
+      @connection.drop_table "postgresql_serials", if_exists: true
+    end
+
+    # This replaces the same test that's been excluded from
+    # PostgresqlSerialTest. The column's type is integer, but it's sql_type is
+    # bigint because CockroachDB's integers are bigints.
+    # See test/excludes/PostgresqlSerialTest.rb
+    def test_serial_column
+      column = PostgresqlSerial.columns_hash["seq"]
+      assert_equal :integer, column.type
+      assert_equal "bigint", column.sql_type
+      assert_predicate column, :serial?
+    end
+
+    # This replaces the same test that's been excluded from
+    # PostgresqlSerialTest. The column's type is integer, but it's sql_type is
+    # bigint because CockroachDB's integers are bigints. The column is also
+    # serial? because it uses the same default function that serial columns use.
+    # See test/excludes/PostgresqlSerialTest.rb
+    def test_not_serial_column
+      column = PostgresqlSerial.columns_hash["serials_id"]
+      assert_equal :integer, column.type
+      assert_equal "bigint", column.sql_type
+      assert_predicate column, :serial?
+    end
+
+    # This replaces the same test that's been excluded from
+    # PostgresqlSerialTest. Although the seq column was created as a serial
+    # column, the dump will include it as a bigserial column. That's because
+    # serial columns are backed by integer columns, and integer columns are
+    # bigints in CockroachDB.
+    # See test/excludes/PostgresqlSerialTest.rb
+    def test_schema_dump_with_shorthand
+      output = dump_table_schema "postgresql_serials"
+      assert_match %r{t\.bigserial\s+"seq",\s+null: false$}, output
+    end
+
+    # This replaces the same test that's been excluded from
+    # PostgresqlSerialTest. The serials_id column wasn't created as a serial
+    # column, but the dump will include it as such because it has the same
+    # default function has a serial column.
+    # See test/excludes/PostgresqlSerialTest.rb
+    def test_schema_dump_with_not_serial
+      output = dump_table_schema "postgresql_serials"
+      assert_match %r{t\.bigserial\s+"serials_id"$}, output
+    end
+  end
+
+  class PostgresqlBigSerialTest < ActiveRecord::PostgreSQLTestCase
+    include SchemaDumpingHelper
+
+    class PostgresqlBigSerial < ActiveRecord::Base; end
+
+    setup do
+      @connection = ActiveRecord::Base.connection
+      @connection.create_table "postgresql_big_serials", force: true do |t|
+        t.bigserial :seq
+
+        # Instead of creating this column with a sequence default, we'll create
+        # it with a unique_rowid() default. This better matches the behavior in
+        # CockroachDB.
+        t.bigint :serials_id, default: -> { "unique_rowid()" }
+      end
+    end
+
+    teardown do
+      @connection.drop_table "postgresql_big_serials", if_exists: true
+    end
+
+    # This replaces the same test that's been excluded from
+    # PostgresqlBigSerialTest. We can run it here because the setup has been
+    # fixed.
+    # See test/excluded/PostgresqlBigSerialTest.rb
+    def test_bigserial_column
+      column = PostgresqlBigSerial.columns_hash["seq"]
+      assert_equal :integer, column.type
+      assert_equal "bigint", column.sql_type
+      assert_predicate column, :serial?
+    end
+
+    # This replaces the same test that's been excluded from
+    # PostgresqlBigSerialTest. The column is serial? because it uses the same
+    # default function that serial columns use.
+    # See test/excludes/PostgresqlBigSerialTest.rb
+    def test_not_bigserial_column
+      column = PostgresqlBigSerial.columns_hash["serials_id"]
+      assert_equal :integer, column.type
+      assert_equal "bigint", column.sql_type
+      assert_predicate column, :serial?
+    end
+
+    # This replaces the same test that's been excluded from
+    # PostgresqlBigSerialTest. We can run it here because the setup has been
+    # fixed.
+    # See test/excluded/PostgresqlBigSerialTest.rb
+    def test_schema_dump_with_shorthand
+      output = dump_table_schema "postgresql_big_serials"
+      assert_match %r{t\.bigserial\s+"seq",\s+null: false$}, output
+    end
+
+    # This replaces the same test that's been excluded from
+    # PostgresqlBigSerialTest. The serials_id column wasn't created as a serial
+    # column, but the dump will include it as such because it has the same
+    # default function has a serial column.
+    # See test/excluded/PostgresqlBigSerialTest.rb
+    def test_schema_dump_with_not_bigserial
+      output = dump_table_schema "postgresql_big_serials"
+      assert_match %r{t\.bigserial\s+"serials_id"$}, output
+    end
+  end
+
+  module SequenceNameDetectionTestCases
+    class CollidedSequenceNameTest < ActiveRecord::PostgreSQLTestCase
+      include SchemaDumpingHelper
+
+      def setup
+        @connection = ActiveRecord::Base.connection
+        @connection.create_table :foo_bar, force: true do |t|
+          t.serial :baz_id
+        end
+        @connection.create_table :foo, force: true do |t|
+          t.serial :bar_id
+          t.bigserial :bar_baz_id
+        end
+      end
+
+      def teardown
+        @connection.drop_table :foo_bar, if_exists: true
+        @connection.drop_table :foo, if_exists: true
+      end
+
+      # This replaces the same test that's been excluded from
+      # SequenceNameDetectionTestCases::CollidedSequenceNameTest. Although
+      # bar_id was created as a serial column, it will get dumped as a bigserial
+      # column. Serial columns are backed by integer columns, and integer
+      # columns are bigints in CockroachDB.
+      # See test/excludes/SequenceNameDetectionTestCases/CollidedSequenceNameTest.rb
+      def test_schema_dump_with_collided_sequence_name
+        output = dump_table_schema "foo"
+        assert_match %r{t\.bigserial\s+"bar_id",\s+null: false$}, output
+        assert_match %r{t\.bigserial\s+"bar_baz_id",\s+null: false$}, output
+      end
+    end
+
+    class LongerSequenceNameDetectionTest < ActiveRecord::PostgreSQLTestCase
+      include SchemaDumpingHelper
+
+      def setup
+        @table_name = "long_table_name_to_test_sequence_name_detection_for_serial_cols"
+        @connection = ActiveRecord::Base.connection
+        @connection.create_table @table_name, force: true do |t|
+          t.serial :seq
+          t.bigserial :bigseq
+        end
+      end
+
+      def teardown
+        @connection.drop_table @table_name, if_exists: true
+      end
+
+      # This replaces the same test that's been excluded from
+      # SequenceNameDetectionTestCases::LongerSequenceNameDetectionTest.
+      # Although seq was created as a serial column, it will get dumped as a bigserial
+      # column. Serial columns are backed by integer columns, and integer
+      # columns are bigints in CockroachDB.
+      # See test/excludes/SequenceNameDetectionTestCases/LongerSequenceNameDetectionTest.rb
+      def test_schema_dump_with_long_table_name
+        output = dump_table_schema @table_name
+        assert_match %r{create_table "#{@table_name}", force: :cascade}, output
+        assert_match %r{t\.bigserial\s+"seq",\s+null: false$}, output
+        assert_match %r{t\.bigserial\s+"bigseq",\s+null: false$}, output
+      end
+    end
+  end
+end

--- a/test/excludes/PostgresqlBigSerialTest.rb
+++ b/test/excludes/PostgresqlBigSerialTest.rb
@@ -1,0 +1,7 @@
+# Note: all these tests fail during setup trying to create a column with a
+# sequence backed default because the sequence doesn't exist. The tests still
+# fail for different reasons after the setup is fixed.
+exclude :test_bigserial_column, "The test is valid but can't pass with the bad setup."
+exclude :test_not_bigserial_column, "The serial? assertion fails because a bigint column with a serial default function is not distinguishable from a serial column. See https://www.cockroachlabs.com/docs/v19.2/serial.html#modes-of-operation."
+exclude :test_schema_dump_with_shorthand, "The test is valid but can't pass with the bad setup."
+exclude :test_schema_dump_with_not_bigserial, "If a bigint column is created with a serial default function, it will be treated like a serial column in CockroachDB."

--- a/test/excludes/PostgresqlSerialTest.rb
+++ b/test/excludes/PostgresqlSerialTest.rb
@@ -1,0 +1,7 @@
+# Note: all these tests fail during setup trying to create a column with a
+# sequence backed default because the sequence doesn't exist. The tests still
+# fail for different reasons after the setup is fixed.
+exclude :test_serial_column, "The sql_type assertion fails because integer columns are bigints in CockroachDB. See https://www.cockroachlabs.com/docs/v19.2/int.html#names-and-aliases."
+exclude :test_not_serial_column, "The sql_type assertion fails because integer columns are bigints in CockroachDB. See https://www.cockroachlabs.com/docs/v19.2/int.html#names-and-aliases. The serial? assertion fails because an integer column with a serial default function is not distinguishable from a serial column. See https://www.cockroachlabs.com/docs/v19.2/serial.html#modes-of-operation."
+exclude :test_schema_dump_with_shorthand, "Serial columns are backed by integer columns, and integer columns are really bigints in CockroachDB. Therefore, the dump will include bigserial instead of serial columns. See https://www.cockroachlabs.com/docs/v19.2/serial.html#generated-values-for-mode-sql_sequence."
+exclude :test_schema_dump_with_not_serial, "If an integer column is created with a serial default function, it will be treated like a serial column in CockroachDB."

--- a/test/excludes/SequenceNameDetectionTestCases/CollidedSequenceNameTest.rb
+++ b/test/excludes/SequenceNameDetectionTestCases/CollidedSequenceNameTest.rb
@@ -1,0 +1,1 @@
+exclude :test_schema_dump_with_collided_sequence_name, "Serial columns are dumped as a bigserials against CockroachDB. This happens because serial columns are backed by integers, and integers are really bigints in CockroachDB. See https://www.cockroachlabs.com/docs/v19.2/serial.html#generated-values-for-mode-sql_sequence."

--- a/test/excludes/SequenceNameDetectionTestCases/LongerSequenceNameDetectionTest.rb
+++ b/test/excludes/SequenceNameDetectionTestCases/LongerSequenceNameDetectionTest.rb
@@ -1,0 +1,1 @@
+exclude :test_schema_dump_with_long_table_name, "Serial columns are dumped as a bigserials against CockroachDB. This happens because serial columns are backed by integers, and integers are really bigints in CockroachDB. See https://www.cockroachlabs.com/docs/v19.2/serial.html#generated-values-for-mode-sql_sequence."


### PR DESCRIPTION
 Most of the PostgreSQL serial tests were failing in ActiveRecord because they were creating columns with default sequence values in their setup. These columns were being used to test the behavior of non-serial columns that look like serial columns. To test the same behavior in CockroachDB, the columns are created with default `unique_rowid()` values. As a result, the behavior in CockroachDB is different. While we can distinguish serial columns from non-serial columns in PostgreSQL, the same can't be done in CockroachDB. An integer column with a `unique_rowid()` default will look like a serial column.

Other tests were failing because they expected serial columns to be dumped as `serial` columns. In CockroachDB, they'll get dumped as `bigserial`s. Serial columns are backed by integer columns, and integers are `bigint`s in CockroachDB.