### PR TITLE
Don't update rowid via ActiveRecord

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb/attribute_methods.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/attribute_methods.rb
@@ -1,0 +1,28 @@
+module ActiveRecord
+  module CockroachDB
+    module AttributeMethodsMonkeyPatch
+
+      private
+
+      # Filter out rowid so it doesn't get inserted by ActiveRecord. rowid is a
+      # column added by CockroachDB for tables that don't define primary keys.
+      # CockroachDB will automatically insert rowid values. See
+      # https://www.cockroachlabs.com/docs/v19.2/create-table.html#create-a-table.
+      def attributes_for_create(attribute_names)
+        super.reject { |name| name == ConnectionAdapters::CockroachDBAdapter::DEFAULT_PRIMARY_KEY }
+      end
+
+      # Filter out rowid so it doesn't get updated by ActiveRecord. rowid is a
+      # column added by CockroachDB for tables that don't define primary keys.
+      # CockroachDB will automatically insert rowid values. See
+      # https://www.cockroachlabs.com/docs/v19.2/create-table.html#create-a-table.
+      def attributes_for_update(attribute_names)
+        super.reject { |name| name == ConnectionAdapters::CockroachDBAdapter::DEFAULT_PRIMARY_KEY }
+      end
+    end
+  end
+
+  class Base
+    prepend CockroachDB::AttributeMethodsMonkeyPatch
+  end
+end

--- a/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
@@ -4,8 +4,6 @@ module ActiveRecord
       module SchemaStatements
         include ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
 
-        DEFAULT_PRIMARY_KEY = "rowid"
-
         def add_index(table_name, column_name, options = {})
           super
         rescue ActiveRecord::StatementInvalid => error
@@ -27,7 +25,7 @@ module ActiveRecord
         def primary_key(table_name)
           pk = super
 
-          if pk == DEFAULT_PRIMARY_KEY
+          if pk == CockroachDBAdapter::DEFAULT_PRIMARY_KEY
             nil
           else
             pk

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -5,6 +5,7 @@ require "active_record/connection_adapters/cockroachdb/transaction_manager"
 require "active_record/connection_adapters/cockroachdb/column"
 require "active_record/connection_adapters/cockroachdb/database_statements"
 require "active_record/connection_adapters/cockroachdb/quoting"
+require "active_record/connection_adapters/cockroachdb/attribute_methods"
 
 module ActiveRecord
   module ConnectionHandling
@@ -34,6 +35,7 @@ module ActiveRecord
   module ConnectionAdapters
     class CockroachDBAdapter < PostgreSQLAdapter
       ADAPTER_NAME = "CockroachDB".freeze
+      DEFAULT_PRIMARY_KEY = "rowid"
 
       include CockroachDB::SchemaStatements
       include CockroachDB::ReferentialIntegrity


### PR DESCRIPTION
CockroachDB adds a `rowid` column to tables that don't define primary keys, and it will update the column as new rows get inserted. ActiveRecord should never need to update `rowid`. See https://www.cockroachlabs.com/docs/v19.2/create-table.html#create-a-table.

This PR also moves the `DEFAULT_PRIMARY_KEY` constant so it can be used in multiple places.