### PR TITLE
ActiveRecord base test fixes

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
@@ -33,6 +33,13 @@ module ActiveRecord
             pk
           end
         end
+
+        # CockroachDB uses unique_rowid() for primary keys, not sequences. It's
+        # possible to force a table to use sequences, but since it's not the
+        # default behavior we'll always return nil for default_sequence_name.
+        def default_sequence_name(table_name, pk = "id")
+          nil
+        end
       end
     end
   end

--- a/test/cases/adapter_test.rb
+++ b/test/cases/adapter_test.rb
@@ -1,8 +1,5 @@
 require "cases/helper_cockroachdb"
 
-# Load dependencies from ActiveRecord test suite
-require "cases/helper"
-
 module CockroachDB
   class AdapterTest < ActiveRecord::TestCase
     self.use_transactional_tests = false

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1,0 +1,31 @@
+require "cases/helper_cockroachdb"
+
+module CockroachDB
+  class BasicsTest < ActiveRecord::TestCase
+    # This replaces the same test that's been excluded from BasicsTest. It's
+    # exactly the same, except badchar has an entry for CockroachDBAdapter.
+    def test_column_names_are_escaped
+      conn      = ActiveRecord::Base.connection
+      classname = conn.class.name[/[^:]*$/]
+      badchar   = {
+        "SQLite3Adapter"    => '"',
+        "Mysql2Adapter"     => "`",
+        "PostgreSQLAdapter" => '"',
+        "OracleAdapter"     => '"',
+        "FbAdapter"         => '"',
+        "CockroachDBAdapter" => '"'
+      }.fetch(classname) {
+        raise "need a bad char for #{classname}"
+      }
+
+      quoted = conn.quote_column_name "foo#{badchar}bar"
+      if current_adapter?(:OracleAdapter)
+        # Oracle does not allow double quotes in table and column names at all
+        # therefore quoting removes them
+        assert_equal("#{badchar}foobar#{badchar}", quoted)
+      else
+        assert_equal("#{badchar}foo#{badchar * 2}bar#{badchar}", quoted)
+      end
+    end
+  end
+end

--- a/test/cases/defaults_test.rb
+++ b/test/cases/defaults_test.rb
@@ -1,0 +1,24 @@
+require "cases/helper_cockroachdb"
+
+# Load dependencies from ActiveRecord test suite
+require "support/schema_dumping_helper"
+
+module CockroachDB
+  class DefaultExpressionTest < ActiveRecord::TestCase
+    include SchemaDumpingHelper
+
+    # This replaces the same test that's been excluded from
+    # PostgresqlDefaultExpressionTest. The assertions have updated to match
+    # against CockroachDB's current_date() and current_timestamp() functions.
+    # See test/excludes/PostgresqlDefaultExpressionTest.rb.
+    test "schema dump includes default expression" do
+      output = dump_table_schema("defaults")
+
+      assert_match %r/t\.date\s+"modified_date",\s+default: -> { \"current_date\(\)\" }/, output
+      assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "current_timestamp\(\)" }/, output
+
+      assert_match %r/t\.date\s+"modified_date_function",\s+default: -> { "now\(\)" }/, output
+      assert_match %r/t\.datetime\s+"modified_time_function",\s+default: -> { "now\(\)" }/, output
+    end
+  end
+end

--- a/test/cases/fixtures_test.rb
+++ b/test/cases/fixtures_test.rb
@@ -1,7 +1,6 @@
 require "cases/helper_cockroachdb"
 
 # Load dependencies from ActiveRecord test suite
-require "cases/helper"
 require "models/account"
 require "models/company"
 require "models/course"

--- a/test/cases/helper_cockroachdb.rb
+++ b/test/cases/helper_cockroachdb.rb
@@ -3,3 +3,22 @@ Bundler.require :default, :development
 
 # Turn on debugging for the test environment
 ENV['DEBUG_COCKROACHDB_ADAPTER'] = "1"
+
+# Load ActiveRecord test helper
+require "cases/helper"
+
+# Load the CockroachDB specific schema. It replaces ActiveRecord's PostgreSQL
+# specific schema.
+def load_cockroachdb_specific_schema
+  # silence verbose schema loading
+  original_stdout = $stdout
+  $stdout = StringIO.new
+
+  load "schema/cockroachdb_specific_schema.rb"
+
+  ActiveRecord::FixtureSet.reset_cache
+ensure
+  $stdout = original_stdout
+end
+
+load_cockroachdb_specific_schema

--- a/test/cases/primary_keys_test.rb
+++ b/test/cases/primary_keys_test.rb
@@ -1,7 +1,6 @@
 require "cases/helper_cockroachdb"
 
 # Load dependencies from ActiveRecord test suite
-require "cases/helper"
 require "support/schema_dumping_helper"
 require "models/topic"
 require "models/mixed_case_monkey"

--- a/test/excludes/BasicsTest.rb
+++ b/test/excludes/BasicsTest.rb
@@ -1,0 +1,1 @@
+exclude :test_column_names_are_escaped, "The test raises an exception because the setup doesn't account for other adpaters like CockroachDBAdapter."

--- a/test/excludes/PostgresqlDefaultExpressionTest.rb
+++ b/test/excludes/PostgresqlDefaultExpressionTest.rb
@@ -1,0 +1,1 @@
+exclude :test_schema_dump_includes_default_expression, "The test fails because CockroachDB uses different functions than PostgreSQL for current date/timestamps. See https://www.cockroachlabs.com/docs/v19.2/functions-and-operators.html#date-and-time-functions."

--- a/test/schema/cockroachdb_specific_schema.rb
+++ b/test/schema/cockroachdb_specific_schema.rb
@@ -1,0 +1,122 @@
+# This is a copy of postgresql_specific_schema.rb from ActiveRecord's test
+# suite. Statements that don't work against CockroachDB have been commented out
+# with an explanation of why they don't work.
+
+ActiveRecord::Schema.define do
+
+  enable_extension!("uuid-ossp", ActiveRecord::Base.connection)
+  enable_extension!("pgcrypto",  ActiveRecord::Base.connection) if ActiveRecord::Base.connection.supports_pgcrypto_uuid?
+
+  uuid_default = connection.supports_pgcrypto_uuid? ? {} : { default: "uuid_generate_v4()" }
+
+  create_table :uuid_parents, id: :uuid, force: true, **uuid_default do |t|
+    t.string :name
+  end
+
+  create_table :uuid_children, id: :uuid, force: true, **uuid_default do |t|
+    t.string :name
+    t.uuid :uuid_parent_id
+  end
+
+  create_table :defaults, force: true do |t|
+    t.date :modified_date, default: -> { "CURRENT_DATE" }
+    t.date :modified_date_function, default: -> { "now()" }
+    t.date :fixed_date, default: "2004-01-01"
+    t.datetime :modified_time, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime :modified_time_function, default: -> { "now()" }
+    t.datetime :fixed_time, default: "2004-01-01 00:00:00.000000-00"
+    t.column :char1, "char(1)", default: "Y"
+    t.string :char2, limit: 50, default: "a varchar field"
+    t.text :char3, default: "a text field"
+    t.bigint :bigint_default, default: -> { "0::bigint" }
+    t.text :multiline_default, default: "--- []
+
+"
+  end
+
+  create_table :postgresql_times, force: true do |t|
+    t.interval :time_interval
+    t.interval :scaled_time_interval, precision: 6
+  end
+
+  create_table :postgresql_oids, force: true do |t|
+    t.oid :obj_id
+  end
+
+  drop_table "postgresql_timestamp_with_zones", if_exists: true
+  drop_table "postgresql_partitioned_table", if_exists: true
+  drop_table "postgresql_partitioned_table_parent", if_exists: true
+
+  execute "DROP SEQUENCE IF EXISTS companies_nonstd_seq CASCADE"
+  execute "CREATE SEQUENCE companies_nonstd_seq START 101 OWNED BY companies.id"
+  execute "ALTER TABLE companies ALTER COLUMN id SET DEFAULT nextval('companies_nonstd_seq')"
+  execute "DROP SEQUENCE IF EXISTS companies_id_seq"
+
+  # Stored procedures are not supported in CockroachDB.
+  # See https://github.com/cockroachdb/cockroach/issues/17511.
+  # execute "DROP FUNCTION IF EXISTS partitioned_insert_trigger()"
+
+  # CockroachDB uses unique_rowid() for primary keys by default instead of
+  # sequences. Therefore, there aren't any sequences to update here.
+  # See https://www.cockroachlabs.com/docs/v19.2/serial.html#modes-of-operation.
+  # %w(accounts_id_seq developers_id_seq projects_id_seq topics_id_seq customers_id_seq orders_id_seq).each do |seq_name|
+  #   execute "SELECT setval('#{seq_name}', 100)"
+  # end
+
+  execute <<_SQL
+  CREATE TABLE postgresql_timestamp_with_zones (
+    id SERIAL PRIMARY KEY,
+    time TIMESTAMP WITH TIME ZONE
+  );
+_SQL
+
+# Since stored procedures are not supported in CockroachDB, it won't be possible
+# to do trigger based partitioning.
+# See https://github.com/cockroachdb/cockroach/issues/17511.
+#   begin
+#     execute <<_SQL
+#     CREATE TABLE postgresql_partitioned_table_parent (
+#       id SERIAL PRIMARY KEY,
+#       number integer
+#     );
+#     CREATE TABLE postgresql_partitioned_table ( )
+#       INHERITS (postgresql_partitioned_table_parent);
+#
+#     CREATE OR REPLACE FUNCTION partitioned_insert_trigger()
+#     RETURNS TRIGGER AS $$
+#     BEGIN
+#       INSERT INTO postgresql_partitioned_table VALUES (NEW.*);
+#       RETURN NULL;
+#     END;
+#     $$
+#     LANGUAGE plpgsql;
+#
+#     CREATE TRIGGER insert_partitioning_trigger
+#       BEFORE INSERT ON postgresql_partitioned_table_parent
+#       FOR EACH ROW EXECUTE PROCEDURE partitioned_insert_trigger();
+# _SQL
+#   rescue ActiveRecord::StatementInvalid => e
+#     if e.message.include?('language "plpgsql" does not exist')
+#       execute "CREATE LANGUAGE 'plpgsql';"
+#       retry
+#     else
+#       raise e
+#     end
+#   end
+
+  # This table is to verify if the :limit option is being ignored for text and binary columns
+  create_table :limitless_fields, force: true do |t|
+    t.binary :binary, limit: 100_000
+    t.text :text, limit: 100_000
+  end
+
+  create_table :bigint_array, force: true do |t|
+    t.integer :big_int_data_points, limit: 8, array: true
+    t.decimal :decimal_array_default, array: true, default: [1.23, 3.45]
+  end
+
+  create_table :uuid_items, force: true, id: false do |t|
+    t.uuid :uuid, primary_key: true, **uuid_default
+    t.string :title
+  end
+end


### PR DESCRIPTION
This includes a few changes to fix [ActiveRecord's base test](https://github.com/rails/rails/blob/ac30e389ecfa0e26e3d44c1eda8488ddf63b3ecc/activerecord/test/cases/base_test.rb).

The biggest change is the introduction of a CockroachDB specific test schema. It's a copy of the PostgreSQL test schema defined by ActiveRecord with a few changes so it works for CockroachDB.

See the commits for more details on the changes.

Note: there's an outstanding failure in the base test. [`test_marshal_between_processes`](https://github.com/rails/rails/blob/ac30e389ecfa0e26e3d44c1eda8488ddf63b3ecc/activerecord/test/cases/base_test.rb#L1187-L1216) causes a Ruby segfault when it tries to open a new connection in a forked process. I'm not sure what's going there so I'm tabling it for now.