### PR TITLE
Skip some CalculationsTests

### DIFF
--- a/test/excludes/CalculationsTest.rb
+++ b/test/excludes/CalculationsTest.rb
@@ -1,1 +1,4 @@
 exclude :test_group_by_with_order_by_virtual_count_attribute, "Ordering with virtual count attributes is not supported against CockroachDB."
+exclude :test_group_by_with_limit, "The test fails because ActiveRecord strips out the query order clause making it impossible to guarantee the results order. See bug issue https://github.com/rails/rails/issues/38936."
+exclude :test_group_by_with_offset, "The test fails because ActiveRecord strips out the query order clause making it impossible to guarantee the results order. See bug issue https://github.com/rails/rails/issues/38936."
+exclude :test_group_by_with_limit_and_offset, "The test fails because ActiveRecord strips out the query order clause making it impossible to guarantee the results order. See bug issue https://github.com/rails/rails/issues/38936."

--- a/test/excludes/CalculationsTest.rb
+++ b/test/excludes/CalculationsTest.rb
@@ -1,0 +1,1 @@
+exclude :test_group_by_with_order_by_virtual_count_attribute, "Ordering with virtual count attributes is not supported against CockroachDB."


### PR DESCRIPTION
Most of the skipped tests fail against CockroachDB because ActiveRecord strips out the query order clause from group by queries making it impossible to guarantee the results order. These tests pass against databases like PostgreSQL because they'll inherently order by the group by clause. This appears to be a bug in ActiveRecord, see https://github.com/rails/rails/issues/38936.

The other test, `:test_group_by_with_order_by_virtual_count_attribute`,  fails because ordering with virtual count attributes doesn't work against CockroachDB.

For example, here’s a `posts` table and it has a `type` column.

```sql
activerecord_unittest=# select posts.type, count(*) from posts group by posts.type;
    type     | count 
-------------+-------
 Post        |     9
 StiPost     |     1
 SpecialPost |     1
(3 rows)
```

If I run a query like `SELECT  MAX(posts.comments_count) AS maximum_comments_count, posts.type AS posts_type FROM posts GROUP BY posts.type ORDER BY posts.count ASC limit 2;` against PostgreSQL, it works.

```sql
activerecord_unittest=# SELECT  MAX(posts.comments_count) AS maximum_comments_count, posts.type AS posts_type FROM posts GROUP BY posts.type ORDER BY posts.count ASC limit 2;
 maximum_comments_count | posts_type  
------------------------+-------------
                      2 | StiPost
                      1 | SpecialPost
(2 rows)
```

When I run the query against CockroachDB, it blows up because `posts.count` isn’t recognized in the `ORDER BY` clause.

```sql
root@localhost:26258/activerecord_unittest> SELECT  MAX(posts.comments_count) AS maximum_comments_count, posts.type AS posts_type FROM posts GROUP BY posts.type ORDER BY posts.count ASC limit 2;
ERROR: column "posts.count" does not exist
```

Is this a know limitation in CockroachDB? I’m not seeing it documented anywhere (it’s kinda hard to search for).