### PR TITLE
Update CI scripts

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile extends the Examples-ORM testing image in order to
 # install specific dependencies required for ActiveRecord tests.
 
-FROM cockroachdb/postgres-test:20170308-1644
+FROM cockroachdb/example-orms-builder:20200413-1918
 
 # Native dependencies for libxml-ruby and sqlite3.
 RUN apt-get update -y && apt-get install -y \

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -2,15 +2,14 @@
 
 set -euo pipefail
 
-# Download CockroachDB. NB: currently this uses an alpha, due to feature
-# requirements.
-VERSION=v2.0-alpha.20171218
+# Download CockroachDB
+VERSION=v20.1.0-rc.1
 wget -qO- https://binaries.cockroachdb.com/cockroach-$VERSION.linux-amd64.tgz | tar  xvz
 readonly COCKROACH=./cockroach-$VERSION.linux-amd64/cockroach
 
 # Make sure cockroach can be found on the path. This is required for the
 # ActiveRecord Rakefile that rebuilds the test database.
-export PATH=$(pwd)/cockroach-$VERSION.linux-amd64/:$PATH
+export PATH=./cockroach-$VERSION.linux-amd64/:$PATH
 readonly urlfile=cockroach-url
 
 run_cockroach() {
@@ -32,45 +31,23 @@ run_cockroach() {
     echo "server not yet available; sleeping for $backoff seconds"
     sleep $backoff
   done
+  cockroach sql --insecure -e 'CREATE DATABASE activerecord_unittest;'
+  cockroach sql --insecure -e 'CREATE DATABASE activerecord_unittest2;'
 }
 
-# Target the Rails dependency file.
-export BUNDLE_GEMFILE=$(pwd)/rails/Gemfile
-
 # Install ruby dependencies.
+gem install bundler:2.1.4
 bundle install
 
-cp build/config.teamcity.yml rails/activerecord/test/config.yml
+run_cockroach
 
-# 'Install' our adapter. This involves symlinking it inside of
-# ActiveRecord. Normally the adapter will transitively install
-# ActiveRecord, but we need to execute tests from inside the Rails
-# context so we cannot rely on that. We also need previous links to make
-# tests idempotent.
-rm -f rails/activerecord/lib/active_record/connection_adapters/cockroachdb_adapter.rb
-ln -s $(pwd)/lib/active_record/connection_adapters/cockroachdb_adapter.rb rails/activerecord/lib/active_record/connection_adapters/cockroachdb_adapter.rb
-rm -rf rails/activerecord/lib/active_record/connection_adapters/cockroachdb
-ln -s $(pwd)/lib/active_record/connection_adapters/cockroachdb rails/activerecord/lib/active_record/connection_adapters/cockroachdb
-
-# Get the test files with "# FILE(OK)". These should pass.
-TESTS=$(cd rails/activerecord && find test/cases -type f \( -name "*_test.rb" \) -exec grep -l "# FILE(OK)" {} +)
-
-for TESTFILE in ${TESTS}; do
-  # Start CockroachDB
-  run_cockroach
-  # Run the tests.
-  echo "Rebuilding database"
-  (cd rails/activerecord && bundle exec rake db:cockroachdb:rebuild)
-  echo "Running test: $TESTFILE"
-  # Run the test. Continue testing even if this file fails.
-  if ! (cd rails/activerecord && bundle exec rake test:cockroachdb TESTFILES=$TESTFILE); then
-    echo "Test FAILED: $TESTFILE"
+if ! (bundle exec rake test); then
+    echo "Tests failed"
     HAS_FAILED=1
-  else
-    echo "Test PASSED: $TESTFILE"
+else
+    echo "Tests passed"
     HAS_FAILED=0
-  fi
-done
+fi
 
 # Attempt a clean shutdown for good measure. We'll force-kill in the
 # exit trap if this script fails.


### PR DESCRIPTION
With these changes, the CI job on TeamCity should start workign again.

We still need to fix the script so it runs all the tests without
crashing. Currently, it only runs two of the test cases.