### PR TITLE
Replace SchemaCacheTest#test_yaml_loads_5_1_dump

### DIFF
--- a/test/cases/connection_adapters/schema_cache_test.rb
+++ b/test/cases/connection_adapters/schema_cache_test.rb
@@ -1,0 +1,31 @@
+require "cases/helper_cockroachdb"
+
+module CockroachDB
+  module ConnectionAdapters
+    class SchemaCacheTest < ActiveRecord::TestCase
+
+      # This replaces the same test that's been excluded from
+      # ActiveRecord::ConnectionAdapters::SchemaCacheTest. It's exactly the
+      # same, but we can run it here by fixing schema_dump_path so it has a
+      # valid path.
+      # See test/excludes/ActiveRecord/ConnectionAdapters/SchemaCacheTest.rb
+      def test_yaml_loads_5_1_dump
+        body = File.open(schema_dump_path).read
+        cache = YAML.load(body)
+
+        assert_no_queries do
+          assert_equal 11, cache.columns("posts").size
+          assert_equal 11, cache.columns_hash("posts").size
+          assert cache.data_sources("posts")
+          assert_equal "id", cache.primary_keys("posts")
+        end
+      end
+
+      private
+
+        def schema_dump_path
+          "#{ASSETS_ROOT}/schema_dump_5_1.yml"
+        end
+    end
+  end
+end

--- a/test/excludes/ActiveRecord/ConnectionAdapters/SchemaCacheTest.rb
+++ b/test/excludes/ActiveRecord/ConnectionAdapters/SchemaCacheTest.rb
@@ -1,0 +1,1 @@
+exclude :test_yaml_loads_5_1_dump, "The test errors because it doesn't properly reference the path to the schema dump. This is a bug in ActiveRecord, and any fix is unlikely to be backported to earlier versions of Rails. See https://github.com/rails/rails/pull/38945."


### PR DESCRIPTION
The ActiveRecord version of the test fails because it references a test file with a relative path. Since the file doesn't exist in the adapter, it blows up. The test has been updated to reference the file with an absolute path via constants defined in AR.

I opened https://github.com/rails/rails/pull/38945 to fix the bug in Rails, but it's unlikely to be backported to previous versions of Rails.