### PR TITLE
Move gem deps for AR test suite to dev group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ require 'openssl'
 source 'https://rubygems.org'
 gemspec
 
-gem 'bcrypt' # used by the ActiveRecord test suite
-
 if ENV['RAILS_SOURCE']
   gemspec path: ENV['RAILS_SOURCE']
 else
@@ -56,6 +54,10 @@ end
 
 group :development do
   gem "byebug"
-  gem "mocha" # used by the ActiveRecord test suite
   gem "minitest-excludes"
+
+  # Gems used by the ActiveRecord test suite
+  gem "bcrypt"
+  gem "mocha"
+  gem "sqlite3"
 end

--- a/test/cases/helper_cockroachdb.rb
+++ b/test/cases/helper_cockroachdb.rb
@@ -1,5 +1,5 @@
 require 'bundler/setup'
-Bundler.require :default, :development
+Bundler.require :development
 
 # Turn on debugging for the test environment
 ENV['DEBUG_COCKROACHDB_ADAPTER'] = "1"


### PR DESCRIPTION
Some gems are needed to run the ActiveRecord test suite, but they're not required to use the adapter. We've had these gems listed in a few places, and now we'll consolidate them under the Gemfile's development group.

This PR also adds sqlite3 as another dep for the ActiveRecord test suite.