### PR TITLE
Exclude failing UniquenessValidationTest cases

### DIFF
--- a/test/excludes/UniquenessValidationTest.rb
+++ b/test/excludes/UniquenessValidationTest.rb
@@ -1,0 +1,2 @@
+exclude :test_validate_uniqueness_uuid, "This test is only meant to be run with a PostgreSQL adapter"
+exclude :testtest_validate_case_insensitive_uniqueness, "This tests relies on an implemented pg_cast table, see cockroach/cockroach#47498 for more details"


### PR DESCRIPTION
Exclude failing `UniquenessValidationTest` test cases.

Relates to https://github.com/cockroachdb/cockroach/issues/47498