### PR TITLE
Replace DirtyTest#test_field_named_field

### DIFF
--- a/test/cases/dirty_test.rb
+++ b/test/cases/dirty_test.rb
@@ -1,0 +1,24 @@
+require "cases/helper"
+
+module CockroachDB
+  class DirtyTest < ActiveRecord::TestCase
+    self.use_transactional_tests = false
+
+    class Testings < ActiveRecord::Base; end
+
+    # This replaces the same test that's been excluded from DirtyTest. We can
+    # run it here with use_transactional_tests set to false.
+    # See test/excludes/DirtyTest.rb
+    def test_field_named_field
+      ActiveRecord::Base.connection.create_table :testings do |t|
+        t.string :field
+      end
+      assert_nothing_raised do
+        Testings.new.attributes
+      end
+    ensure
+      ActiveRecord::Base.connection.drop_table :testings rescue nil
+      ActiveRecord::Base.clear_cache!
+    end
+  end
+end

--- a/test/excludes/DirtyTest.rb
+++ b/test/excludes/DirtyTest.rb
@@ -1,0 +1,1 @@
+exclude :test_field_named_field, "Rails transactional tests are being used while making schema changes. See https://www.cockroachlabs.com/docs/stable/online-schema-changes.html#limited-support-for-schema-changes-within-transactions."


### PR DESCRIPTION
The test fails because a schema change is being made inside a transaction which is not supported by CockroachDB. By setting `use_transactional_tests` to false, we can run the test outside of any transactions.