### PR TITLE
Don't load AR test helper in individual test files

### DIFF
--- a/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/test/cases/adapters/postgresql/active_schema_test.rb
@@ -1,8 +1,5 @@
 require "cases/helper_cockroachdb"
 
-# Load dependencies from ActiveRecord test suite
-require "cases/helper"
-
 module CockroachDB
   class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     def setup

--- a/test/cases/adapters/postgresql/serial_test.rb
+++ b/test/cases/adapters/postgresql/serial_test.rb
@@ -1,7 +1,6 @@
 require "cases/helper_cockroachdb"
 
 # Load dependencies from ActiveRecord test suite
-require "cases/helper"
 require "support/schema_dumping_helper"
 
 module CockroachDB

--- a/test/cases/associations/eager_load_nested_include_test.rb
+++ b/test/cases/associations/eager_load_nested_include_test.rb
@@ -5,7 +5,6 @@
 require "cases/helper_cockroachdb"
 
 # Load dependencies from ActiveRecord test suite
-require "cases/helper"
 require "models/post"
 require "models/tag"
 require "models/author"

--- a/test/cases/associations/left_outer_join_association_test.rb
+++ b/test/cases/associations/left_outer_join_association_test.rb
@@ -1,7 +1,6 @@
 require "cases/helper_cockroachdb"
 
 # Load dependencies from ActiveRecord test suite
-require "cases/helper"
 require "models/post"
 require "models/author"
 


### PR DESCRIPTION
Thanks to #62, the ActiveRecord test helper is now loaded by the CockroachDB test helper that's already loaded by every test.

https://github.com/cockroachdb/activerecord-cockroachdb-adapter/blob/79d2f44119d8b0bb8f89d824c1d463dd9d1d4954/test/cases/helper_cockroachdb.rb#L7-L8

There's no longer a need to load it in individual tests.