### PR TITLE
Exclude UnsafeRawSqlTest case

### DIFF
--- a/test/excludes/UnsafeRawSqlTest.rb
+++ b/test/excludes/UnsafeRawSqlTest.rb
@@ -1,0 +1,1 @@
+exclude "test_order:_allows_NULLS_FIRST_and_NULLS_LAST_too", "This functionality is not yet implemented, see https://github.com/cockroachdb/cockroach/issues/6224 for more details"


### PR DESCRIPTION
Excludes `UnsafeRawSqlTest` case due to pending implementation in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/6224 for more details