### PR TITLE
Skip PessimisticLockingTest custom lock statement test

### DIFF
--- a/test/excludes/PessimisticLockingTest.rb
+++ b/test/excludes/PessimisticLockingTest.rb
@@ -1,0 +1,1 @@
+exclude :test_lock_sending_custom_lock_statement, "NOWAIT lock wait policy is not supported by CockroachDB. See https://github.com/cockroachdb/cockroach/issues/40476."


### PR DESCRIPTION
The test tries to use a NOWAIT lock wait policy but it's not supported by CockroachDB. See https://github.com/cockroachdb/cockroach/issues/40476.