### PR TITLE
Replace OrTest#test_or_when_grouping

### DIFF
--- a/test/cases/relation/or_test.rb
+++ b/test/cases/relation/or_test.rb
@@ -1,0 +1,26 @@
+# This test has been copied to fix a bug in the test setup. It can be removed
+# once the bugfix has been released in Rails - see rails/rails#38978.
+# See test/excludes/OrTest.rb
+
+require "cases/helper_cockroachdb"
+
+# Load dependencies from ActiveRecord test suite
+require "cases/helper"
+require "models/post"
+require "models/author"
+require "models/categorization"
+
+module CockroachDB
+  module ActiveRecord
+    class OrTest < ActiveRecord::TestCase
+      fixtures :posts
+      fixtures :authors, :author_addresses
+
+      def test_or_when_grouping
+        groups = Post.where("id < 10").group("body")
+        expected = groups.having("COUNT(*) > 1 OR body like 'Such%'").count
+        assert_equal expected, groups.having("COUNT(*) > 1").or(groups.having("body like 'Such%'")).count
+      end
+    end
+  end
+end

--- a/test/excludes/OrTest.rb
+++ b/test/excludes/OrTest.rb
@@ -1,0 +1,1 @@
+exclude :test_or_when_groupoing, "This test produces a non-deterministic result. See rails/rails#38978 for fix; patch replicated in adapter test"


### PR DESCRIPTION
Replaces `OrTest#test_or_when_grouping` due to non-deterministic test output. 

This has been [fixed upstream in Rails](https://github.com/rails/rails/pull/38978); the fix is replicated here to cover our needs.

Closes #87 