### PR TITLE
Use start-single-node command in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -21,7 +21,7 @@ run_cockroach() {
   cockroach quit --insecure || true
   rm -rf cockroach-data
   # Start CockroachDB.
-  cockroach start --insecure --host=localhost --listening-url-file="$urlfile" >/dev/null 2>&1 &
+  cockroach start-single-node --insecure --host=localhost --listening-url-file="$urlfile" >/dev/null 2>&1 &
   # Ensure CockroachDB is stopped on script exit.
   trap "echo 'Exit routine: Killing CockroachDB.' && kill -9 $! &> /dev/null" EXIT
   # Wait until CockroachDB has started.


### PR DESCRIPTION
This sets up the database with settings that make more sense for
single-node clusters. For example, it disables replication.