### PR TITLE
Fix migration_test failures/errors

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -103,8 +103,7 @@ module ActiveRecord
       end
 
       def supports_advisory_locks?
-        # FIXME(joey): We may want to make this false.
-        true
+        false
       end
 
       def supports_virtual_columns?

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -56,6 +56,10 @@ module ActiveRecord
         100000
       end
 
+      def supports_bulk_alter?
+        false
+      end
+
       def supports_json?
         # FIXME(joey): Add a version check.
         true

--- a/test/cases/migration_test.rb
+++ b/test/cases/migration_test.rb
@@ -1,0 +1,117 @@
+require "cases/helper_cockroachdb"
+
+module CockroachDB
+  class BulkAlterTableMigrationsTest < ActiveRecord::TestCase
+    def setup
+      @connection = Person.connection
+      @connection.create_table(:delete_me, force: true) { |t| }
+      Person.reset_column_information
+      Person.reset_sequence_name
+    end
+
+    teardown do
+      Person.connection.drop_table(:delete_me) rescue nil
+    end
+
+    def test_adding_multiple_columns
+      classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
+      expected_query_count = {
+        "CockroachDBAdapter" => 2, # one for bulk change, one for comment
+      }.fetch(classname) {
+          raise "need an expected query count for #{classname}"
+        }
+
+        assert_queries(expected_query_count) do
+          with_bulk_change_table do |t|
+            t.column :name, :string
+            t.string :qualification, :experience
+            t.integer :age, default: 0
+            t.date :birthdate, comment: "This is a comment"
+            t.timestamps null: true
+          end
+        end
+
+        assert_equal 8, columns.size
+        [:name, :qualification, :experience].each { |s| assert_equal :string, column(s).type }
+        assert_equal "0", column(:age).default
+        assert_equal "This is a comment", column(:birthdate).comment
+    end
+
+    def test_changing_columns
+      with_bulk_change_table do |t|
+        t.string :name
+        t.date :birthdate
+      end
+
+      assert ! column(:name).default
+      assert_equal :date, column(:birthdate).type
+
+      classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
+      expected_query_count = {
+        "CockroachDBAdapter" => 3, # one query for columns, one for bulk change, one for comment
+      }.fetch(classname) {
+          raise "need an expected query count for #{classname}"
+        }
+
+        assert_queries(expected_query_count, ignore_none: true) do
+          with_bulk_change_table do |t|
+            t.change :name, :string, default: "NONAME"
+            t.change :birthdate, :datetime, comment: "This is a comment"
+          end
+        end
+
+        assert_equal "NONAME", column(:name).default
+        assert_equal :datetime, column(:birthdate).type
+        assert_equal "This is a comment", column(:birthdate).comment
+    end
+  end
+
+  def test_adding_indexes
+    with_bulk_change_table do |t|
+      t.string :username
+      t.string :name
+      t.integer :age
+    end
+
+    classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
+    expected_query_count = {
+      "CockroachDBAdapter" => 2,
+    }.fetch(classname) {
+        raise "need an expected query count for #{classname}"
+      }
+
+      assert_queries(expected_query_count) do
+        with_bulk_change_table do |t|
+          t.index :username, unique: true, name: :awesome_username_index
+          t.index [:name, :age]
+        end
+      end
+    end
+
+  private
+
+    def with_bulk_change_table
+      # Reset columns/indexes cache as we're changing the table
+      @columns = @indexes = nil
+
+      Person.connection.change_table(:delete_me, bulk: true) do |t|
+        yield t
+      end
+    end
+
+    def column(name)
+      columns.detect { |c| c.name == name.to_s }
+    end
+
+    def columns
+      @columns ||= Person.connection.columns("delete_me")
+    end
+
+    def index(name)
+      indexes.detect { |i| i.name == name.to_s }
+    end
+
+    def indexes
+      @indexes ||= Person.connection.indexes("delete_me")
+    end
+  end

--- a/test/cases/migration_test.rb
+++ b/test/cases/migration_test.rb
@@ -86,10 +86,9 @@ module CockroachDB
           t.index [:name, :age]
         end
       end
-    end
+  end
 
   private
-
     def with_bulk_change_table
       # Reset columns/indexes cache as we're changing the table
       @columns = @indexes = nil
@@ -114,4 +113,4 @@ module CockroachDB
     def indexes
       @indexes ||= Person.connection.indexes("delete_me")
     end
-  end
+end

--- a/test/excludes/BulkAlterTableMigrationsTest.rb
+++ b/test/excludes/BulkAlterTableMigrationsTest.rb
@@ -1,0 +1,3 @@
+exclude :test_adding_indexes, "See test/cases/migration_test.rb for CockroachDB-specific test case"
+exclude :test_changing_columns, "See test/cases/migration_test.rb for CockroachDB-specific test case"
+exclude :test_adding_multiple_columns, "See test/cases/migration_test.rb for CockroachDB-specific test case"

--- a/test/excludes/ExplicitlyNamedIndexMigrationTest.rb
+++ b/test/excludes/ExplicitlyNamedIndexMigrationTest.rb
@@ -1,0 +1,1 @@
+exclude :test_drop_index_by_name, "This isn't supported by CockroachDB; see https://www.cockroachlabs.com/docs/stable/online-schema-changes.html#examples-of-statements-that-fail for more information"

--- a/test/excludes/MigrationTest.rb
+++ b/test/excludes/MigrationTest.rb
@@ -1,0 +1,2 @@
+exclude :test_create_table_with_query, "Two columns are created in CockroachDB since this query does not create a pk"
+exclude :test_create_table_with_query_from_relation, "Two columns are created in CockroachDB since this query does not create a pk"

--- a/test/excludes/MigrationTest.rb
+++ b/test/excludes/MigrationTest.rb
@@ -1,2 +1,3 @@
 exclude :test_create_table_with_query, "Two columns are created in CockroachDB since this query does not create a pk"
 exclude :test_create_table_with_query_from_relation, "Two columns are created in CockroachDB since this query does not create a pk"
+exclude :test_add_table_with_decimals, "CockroachDB uses 64-bit signed integers, whereas the default for PG is 32-bit. The Rails test does not accommodate the 64-bit case"

--- a/test/excludes/ReservedWordsMigrationTest.rb
+++ b/test/excludes/ReservedWordsMigrationTest.rb
@@ -1,0 +1,1 @@
+exclude :test_drop_index_from_table_named_values, "This isn't supported by CockroachDB; see https://www.cockroachlabs.com/docs/stable/online-schema-changes.html#examples-of-statements-that-fail for more information"


### PR DESCRIPTION
This PR fixes the errors and failures in `migration_test`. Fixes are a mix of ignoring incompatible tests, modifying tests to reflect actual behavior, and tweaking the adapter itself.

Closes #85 