### PR TITLE
Fix typo in test name

### DIFF
--- a/test/excludes/OrTest.rb
+++ b/test/excludes/OrTest.rb
@@ -1,1 +1,1 @@
-exclude :test_or_when_groupoing, "This test produces a non-deterministic result. See rails/rails#38978 for fix; patch replicated in adapter test"
+exclude :test_or_when_grouping, "This test produces a non-deterministic result. See rails/rails#38978 for fix; patch replicated in adapter test"


### PR DESCRIPTION
Fix a typo in excluded test `test_or_when_grouping`