### PR TITLE
Switch namespacing order in or_test.rb

### DIFF
--- a/test/cases/relation/or_test.rb
+++ b/test/cases/relation/or_test.rb
@@ -10,8 +10,8 @@ require "models/post"
 require "models/author"
 require "models/categorization"
 
-module CockroachDB
-  module ActiveRecord
+module ActiveRecord
+  module CockroachDB
     class OrTest < ActiveRecord::TestCase
       fixtures :posts
       fixtures :authors, :author_addresses


### PR DESCRIPTION
Switch namespacing order in `or_test.rb`

`CockroachDB::ActiveRecord` -> `ActiveRecord::CockroachDB`