### PR TITLE
Exclude/Modify some tests in migrations/columns_test.rb

### DIFF
--- a/test/cases/migration/columns_test.rb
+++ b/test/cases/migration/columns_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "cases/migration/helper"
+
+module ActiveRecord
+  module CockroachDB
+    class Migration
+      class ColumnsTest < ActiveRecord::TestCase
+        include ActiveRecord::Migration::TestHelper
+
+        self.use_transactional_tests = false
+
+        # This file replaces the same tests that have been excluded from ColumnsTest
+        # (see test/excludes/ActiveRecord/Migration/ColumnsTest.rb). New, unsaved
+        # records won't have string default values if the default has been changed
+        # in the database. This happens because once a column default is changed
+        # in CockroachDB, the type information on the value is missing.
+        # We can still verify the desired behavior by persisting the test records.
+        # When ActiveRecord fetches the records from the database, they'll have
+        # their default values.
+
+        def test_change_column_default
+          add_column "test_models", "first_name", :string
+          connection.change_column_default "test_models", "first_name", "Tester"
+          TestModel.reset_column_information
+
+          # Instead of using an unsaved TestModel record, persist one and fetch
+          # it from the database to get the new default value for type.
+
+          TestModel.create!
+          test_model = TestModel.last
+          assert_equal "Tester", test_model.first_name
+        end
+
+        def test_change_column_default_with_from_and_to
+          add_column "test_models", "first_name", :string
+          connection.change_column_default "test_models", "first_name", from: nil, to: "Tester"
+          TestModel.reset_column_information
+
+          # Instead of using an unsaved TestModel record, persist one and fetch
+          # it from the database to get the new default value for type.
+
+          TestModel.create!
+          test_model = TestModel.last
+          assert_equal "Tester", test_model.first_name
+        end
+      end
+    end
+  end
+end

--- a/test/excludes/ActiveRecord/Migration/ColumnsTest.rb
+++ b/test/excludes/ActiveRecord/Migration/ColumnsTest.rb
@@ -1,0 +1,4 @@
+exclude :test_change_column, "This operation is not currently supported in CockroachDB, see cockroachdb/cockroach#9851"
+exclude :test_change_column_default, "This test fails because type information is stripped from string column default values when the default is changed in the database. Possibly caused by https://github.com/cockroachdb/cockroach/issues/47285."
+exclude :test_change_column_default_with_from_and_to, "This test fails because type information is stripped from string column default values when the default is changed in the database. Possibly caused by https://github.com/cockroachdb/cockroach/issues/47285."
+exclude :test_remove_column_with_multi_column_index, "This test fails because it lacks the requisite CASCADE clause to fully remove the column"


### PR DESCRIPTION
Excludes the following tests in `migrations/columns_test.rb`:

`:test_change_column` -> not currently compatible with CockroachDB
`:test_remove_column_with_multi_column_index` -> this test errors (as expected) as written

The following tests are modified:
`:test_change_column_default`, `:test_change_column_default_with_from_and_to`
See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/pull/72 for additional details

Closes #80 