### PR TITLE
Modify PersistenceTest case to not use transactions

### DIFF
--- a/test/cases/persistence_test.rb
+++ b/test/cases/persistence_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/topic"
+
+module CockroachDB
+  class PersistenceTest < ActiveRecord::TestCase
+    fixtures :topics
+
+    self.use_transactional_tests = false
+
+    # This test is identical to the one found in Rails, except we need to run
+    # it with transactions turned off in order to properly assert on the newly
+    # added column.
+    def test_reset_column_information_resets_children
+      child_class = Class.new(Topic)
+      child_class.new # force schema to load
+
+      ActiveRecord::Base.connection.add_column(:topics, :foo, :string)
+      Topic.reset_column_information
+
+      # this should redefine attribute methods
+      child_class.new
+
+      assert child_class.instance_methods.include?(:foo)
+      assert child_class.instance_methods.include?(:foo_changed?)
+      assert_equal "bar", child_class.new(foo: :bar).foo
+    ensure
+      ActiveRecord::Base.connection.remove_column(:topics, :foo)
+      Topic.reset_column_information
+    end
+  end
+end

--- a/test/excludes/PersistenceTest.rb
+++ b/test/excludes/PersistenceTest.rb
@@ -1,0 +1,1 @@
+exclude :test_reset_column_information_resets_children, "This test fails because the column is created in the same transaction in which the test attempts to assert/operate further."


### PR DESCRIPTION
Modifies one failing test in `persistence_test.rb` that was failing due to assertions residing in the same transaction as the change upon which they were attempting to assert. Fixed by disabling transactional tests for the failing case.

Closes #86 