### PR TITLE
Exclude failing PostgresqlNumberTest

### DIFF
--- a/test/excludes/PostgresqlNumberTest.rb
+++ b/test/excludes/PostgresqlNumberTest.rb
@@ -1,0 +1,1 @@
+exclude :test_values, "This test fails for an unknown reason on 'assert_equal ::Float::INFINITY, second.double' because Infinity is being cast to 0.0. See #77 for more details"


### PR DESCRIPTION
Excludes `test_values` test case due to the following failed assertion:

`assert_equal ::Float::INFINITY, second.double`

This test fails specifically because `Infinity` is being cast to `0.0` when inserted into the database as a double-precision Float. Interestingly, `-Infinity` is handled correctly.

Calling the following in an interactive debugging session suggests that the issue may not lie with Active Record:

```
$ second.attributes_before_type_cast
{"id"=>2, "single"=>-Infinity, "double"=>0.0}
```

Both PG and CockroachDB use the [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754) standard for handling special cases `Infinity` and `-Infinity`.

Relates to #77 