### PR TITLE
Exclude flaky bulk insert test

### DIFF
--- a/test/excludes/FixturesTest.rb
+++ b/test/excludes/FixturesTest.rb
@@ -1,1 +1,2 @@
 exclude :test_bulk_insert_multiple_table_with_a_multi_statement_query, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
+exclude :test_bulk_insert_with_a_multi_statement_query_in_a_nested_transaction, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"


### PR DESCRIPTION
The test_bulk_insert_with_a_multi_statement_query_in_a_nested_transaction is failing sometimes, so skip it for now.