### PR TITLE
Update adapter so it runs against Rails 6

### DIFF
--- a/activerecord-cockroachdb-adapter.gemspec
+++ b/activerecord-cockroachdb-adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Allows the use of CockroachDB as a backend for ActiveRecord and Rails apps."
   spec.homepage      = "https://github.com/cockroachdb/activerecord-cockroachdb-adapter"
 
-  spec.add_dependency "activerecord", "~> 5.2"
+  spec.add_dependency "activerecord", "~> 6.0"
   spec.add_dependency "pg", ">= 0.20"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
A few small changes will let the adapter run against Rails 6.

`ActiveRecord::ConnectionHandling#cockroachdb_connection` now sends a connection object to the adapter to match the PostgreSQLAdapter's behavior. See https://github.com/rails/rails/pull/34232.

Instead of merging this change into master, it might be nice to have different branches for each version of the adpater. For example, the ActiveRecord SQL Server Adapter has [branches `4-2-stable` and `5-2-stable`](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/branches) for versions that support Rails 4.2 and Rails 5.2 respectively.