### PR TITLE
[Fix] Relation test override

### DIFF
--- a/test/cases/relation_test.rb
+++ b/test/cases/relation_test.rb
@@ -1,0 +1,26 @@
+require "cases/helper_cockroachdb"
+
+require "cases/helper"
+require "models/post"
+require "models/comment"
+require "models/author"
+require "models/rating"
+require "models/categorization"
+
+module ActiveRecord
+  module CockroachDB
+    class RelationTest < ActiveRecord::TestCase
+      fixtures :posts
+
+      def test_relation_with_annotation_includes_comment_in_to_sql
+        post_with_annotation = Post.where(id: 1).annotate("foo")
+        assert_match %r{= '1' /\* foo \*/}, post_with_annotation.to_sql
+      end
+
+      def test_relation_with_annotation_filters_sql_comment_delimiters
+        post_with_annotation = Post.where(id: 1).annotate("**//foo//**")
+        assert_match %r{= '1' /\* foo \*/}, post_with_annotation.to_sql
+      end
+    end
+  end
+end

--- a/test/excludes/RelationTest.rb
+++ b/test/excludes/RelationTest.rb
@@ -1,1 +1,3 @@
 exclude :test_finding_with_sanitized_order, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
+exclude :test_relation_with_annotation_filters_sql_comment_delimiters, "Skipping test because the new feature from rails 6 annotate, this dont raise any error"
+exclude :test_relation_with_annotation_includes_comment_in_to_sql, "Skipping test because the new feature from rails 6 annotate, this dont raise any error"

--- a/test/excludes/RelationTest.rb
+++ b/test/excludes/RelationTest.rb
@@ -1,3 +1,3 @@
 exclude :test_finding_with_sanitized_order, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
-exclude :test_relation_with_annotation_filters_sql_comment_delimiters, "Skipping test because the new feature from rails 6 annotate, this dont raise any error"
-exclude :test_relation_with_annotation_includes_comment_in_to_sql, "Skipping test because the new feature from rails 6 annotate, this dont raise any error"
+exclude :test_relation_with_annotation_filters_sql_comment_delimiters, "This test is overridden for CockroachDB because this adapter adds quotes to numeric values."
+exclude :test_relation_with_annotation_includes_comment_in_to_sql, "This test is overridden for CockroachDB because this adapter adds quotes to numeric values."


### PR DESCRIPTION
This PR override 2 tests from Relation tests: `test_relation_with_annotation_includes_comment_in_to_sql` and `test_relation_with_annotation_filters_sql_comment_delimiters`

The activerecord tests are expecting that `Post.where(id: 1)` returns `... WHERE id = 1`, but with a quote feature from cockroachdb it returns `... WHERE id = '1'`.

This behavior is already in the old version in production, so it will not raise an error.