### PR TITLE
[FIX] Remove override method suport_ranges

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -80,11 +80,6 @@ module ActiveRecord
         false
       end
 
-      def supports_ranges?
-        # See cockroachdb/cockroach#17022
-        false
-      end
-
       def supports_materialized_views?
         false
       end


### PR DESCRIPTION
This PR removes method `suport_ranges?` this method is deprecated and fully removed from rails 6.1