### PR TITLE
[Fix] Adapter test foreign key verification

### DIFF
--- a/test/cases/adapter_test.rb
+++ b/test/cases/adapter_test.rb
@@ -1,4 +1,8 @@
 require "cases/helper_cockroachdb"
+require "models/binary"
+require "models/developer"
+require "models/post"
+require "models/author"
 
 module CockroachDB
   class AdapterTest < ActiveRecord::TestCase
@@ -53,6 +57,20 @@ module CockroachDB
       @connection = ActiveRecord::Base.connection
     end
 
+    def test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false
+      klass_has_fk = Class.new(ActiveRecord::Base) do
+        self.table_name = "fk_test_has_fk"
+      end
+
+      error = assert_raises(ActiveRecord::InvalidForeignKey) do
+        has_fk = klass_has_fk.new
+        has_fk.fk_id = 1231231231
+        has_fk.save(validate: false)
+      end
+
+      assert_not_nil error.cause
+    end
+
     # This is override to prevent an intermittent error
     # Table fk_test_has_pk has constrain droped and not created back
     def test_foreign_key_violations_on_insert_are_translated_to_specific_exception
@@ -91,6 +109,8 @@ module CockroachDB
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     self.use_transactional_tests = false
 
+    fixtures :posts, :authors, :author_addresses
+
     class Widget < ActiveRecord::Base
       self.primary_key = "widgetid"
     end
@@ -102,6 +122,7 @@ module CockroachDB
     teardown do
       @connection.drop_table :widgets, if_exists: true
       @connection.exec_query("DROP SEQUENCE IF EXISTS widget_seq")
+      @connection.exec_query("DROP SEQUENCE IF EXISTS widgets_seq")
     end
 
     # This test replaces the excluded test_reset_empty_table_with_custom_pk. We
@@ -117,6 +138,47 @@ module CockroachDB
         )
       ")
       assert_equal 1, Widget.create(name: "weather").id
+    end
+
+    def test_truncate_tables
+      assert_operator Post.count, :>, 0
+      assert_operator Author.count, :>, 0
+      assert_operator AuthorAddress.count, :>, 0
+
+      @connection.truncate_tables("author_addresses", "authors", "posts")
+
+      assert_equal 0, Post.count
+      assert_equal 0, Author.count
+      assert_equal 0, AuthorAddress.count
+    ensure
+      reset_fixtures("author_addresses", "authors", "posts")
+    end
+
+    def test_truncate_tables_with_query_cache
+      @connection.enable_query_cache!
+
+      assert_operator Post.count, :>, 0
+      assert_operator Author.count, :>, 0
+      assert_operator AuthorAddress.count, :>, 0
+
+      @connection.truncate_tables("author_addresses", "authors", "posts")
+
+      assert_equal 0, Post.count
+      assert_equal 0, Author.count
+      assert_equal 0, AuthorAddress.count
+    ensure
+      reset_fixtures("author_addresses", "authors", "posts")
+      @connection.disable_query_cache!
+    end
+
+    private
+
+    def reset_fixtures(*fixture_names)
+      ActiveRecord::FixtureSet.reset_cache
+
+      fixture_names.each do |fixture_name|
+        ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, fixture_name)
+      end
     end
   end
 end

--- a/test/cases/adapter_test.rb
+++ b/test/cases/adapter_test.rb
@@ -44,6 +44,50 @@ module CockroachDB
     end
   end
 
+  class AdapterForeignKeyTest < ActiveRecord::TestCase
+    self.use_transactional_tests = false
+
+    fixtures :fk_test_has_pk
+
+    def setup
+      @connection = ActiveRecord::Base.connection
+    end
+
+    # This is override to prevent an intermittent error
+    # Table fk_test_has_pk has constrain droped and not created back
+    def test_foreign_key_violations_on_insert_are_translated_to_specific_exception
+      error = assert_raises(ActiveRecord::InvalidForeignKey) do
+        insert_into_fk_test_has_fk
+      end
+
+      assert_not_nil error.cause
+    end
+
+    # This is override to prevent an intermittent error
+    # Table fk_test_has_pk has constrain droped and not created back
+    def test_foreign_key_violations_on_delete_are_translated_to_specific_exception
+      insert_into_fk_test_has_fk fk_id: 1
+
+      error = assert_raises(ActiveRecord::InvalidForeignKey) do
+        @connection.execute "DELETE FROM fk_test_has_pk WHERE pk_id = 1"
+      end
+
+      assert_not_nil error.cause
+    end
+
+    private
+
+    def insert_into_fk_test_has_fk(fk_id: 0)
+      # Oracle adapter uses prefetched primary key values from sequence and passes them to connection adapter insert method
+      if @connection.prefetch_primary_key?
+        id_value = @connection.next_sequence_value(@connection.default_sequence_name("fk_test_has_fk", "id"))
+        @connection.execute "INSERT INTO fk_test_has_fk (id,fk_id) VALUES (#{id_value},#{fk_id})"
+      else
+        @connection.execute "INSERT INTO fk_test_has_fk (fk_id) VALUES (#{fk_id})"
+      end
+    end
+  end
+
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     self.use_transactional_tests = false
 

--- a/test/excludes/ActiveRecord/AdapterForeignKeyTest.rb
+++ b/test/excludes/ActiveRecord/AdapterForeignKeyTest.rb
@@ -1,4 +1,3 @@
 exclude :test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
-exclude :test_foreign_key_violations_are_translated_to_specific_exception, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
 exclude :test_foreign_key_violations_on_insert_are_translated_to_specific_exception, "This is override to prevent an intermittent error. Table fk_test_has_pk has constrain droped and not created back"
 exclude :test_foreign_key_violations_on_delete_are_translated_to_specific_exception, "This is override to prevent an intermittent error. Table fk_test_has_pk has constrain droped and not created back"

--- a/test/excludes/ActiveRecord/AdapterForeignKeyTest.rb
+++ b/test/excludes/ActiveRecord/AdapterForeignKeyTest.rb
@@ -1,2 +1,4 @@
 exclude :test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
 exclude :test_foreign_key_violations_are_translated_to_specific_exception, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
+exclude :test_foreign_key_violations_on_insert_are_translated_to_specific_exception, "This is override to prevent an intermittent error. Table fk_test_has_pk has constrain droped and not created back"
+exclude :test_foreign_key_violations_on_delete_are_translated_to_specific_exception, "This is override to prevent an intermittent error. Table fk_test_has_pk has constrain droped and not created back"

--- a/test/excludes/ActiveRecord/AdapterTestWithoutTransaction.rb
+++ b/test/excludes/ActiveRecord/AdapterTestWithoutTransaction.rb
@@ -1,1 +1,3 @@
 exclude :test_reset_empty_table_with_custom_pk, "The test fails because serial primary keys in CockroachDB are created with unique_rowid() where PostgreSQL will create them with a sequence. See https://www.cockroachlabs.com/docs/v19.2/serial.html#modes-of-operation"
+exclude :test_truncate_tables, "This is override to prevent an intermittent error. Table fk_test_has_pk has constrain droped and not created back"
+exclude :test_truncate_tables_with_query_cache, "This is override to prevent an intermittent error. Table fk_test_has_pk has constrain droped and not created back"


### PR DESCRIPTION
This PR overrides the foreign key test to prevent an intermittent error.
During the tests, the table fk_test_has_pk has the constrain dropped and not created back.