### PR TITLE
[FIX] Skip test_vebose_query_logs test

### DIFF
--- a/test/excludes/ActiveRecord/LogSubscriberTest.rb
+++ b/test/excludes/ActiveRecord/LogSubscriberTest.rb
@@ -1,0 +1,1 @@
+exclude :test_vebose_query_logs, "Skip the test for not including the bundler gems files in the log, as the rails is obtained from the source"


### PR DESCRIPTION
The LogSubscriber class makes a backtrace clean from `ActiveSupport` on caller locations and removes all bundlers gems calls with a filter:
`gems_regexp = %r{(#{gems_paths.join('|')})/(bundler/)?gems/([^/]+)-([\w.]+)/(.*)}`

The Gemfile gets the rails from soruce (`gem 'rails', git: "https://github.com/rails/rails.git", tag: "v#{version}"`), so rails stay located on bundler with a hash of last commit `.rvm/gems/ruby-2.7.1/bundler/gems/rails-daae2c8ad0c8/...`.

So the `ActiveSupport` filter removes it, and the test will never pass, so as the filter is right we need to skip this test.
