### PR TITLE
[Fix] Foreign key test transaction

### DIFF
--- a/test/cases/migration/foreign_key_test.rb
+++ b/test/cases/migration/foreign_key_test.rb
@@ -165,6 +165,18 @@ module ActiveRecord
           assert_equal [], @connection.foreign_keys("astronauts")
         end
 
+        def test_remove_foreign_key_by_the_select_one_on_the_same_table
+          @connection.add_foreign_key :astronauts, :rockets
+          @connection.add_reference :astronauts, :myrocket, foreign_key: { to_table: :rockets }
+
+          assert_equal 2, @connection.foreign_keys("astronauts").size
+
+          @connection.remove_foreign_key :astronauts, :rockets, column: "myrocket_id"
+
+          assert_equal [["astronauts", "rockets", "rocket_id"]],
+            @connection.foreign_keys("astronauts").map { |fk| [fk.from_table, fk.to_table, fk.column] }
+        end
+
         def test_add_invalid_foreign_key
           @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", validate: false
 

--- a/test/excludes/ActiveRecord/Migration/ForeignKeyTest.rb
+++ b/test/excludes/ActiveRecord/Migration/ForeignKeyTest.rb
@@ -25,3 +25,4 @@ exclude :test_add_foreign_key_with_prefix, "This test fails due to the transacti
 exclude :test_add_foreign_key_with_suffix, "This test fails due to the transactional nature of the test. Disabling transactions will make the test pass."
 exclude :test_foreign_keys, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
 exclude :test_schema_dumping_with_options, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
+exclude :test_remove_foreign_key_by_the_select_one_on_the_same_table, "This test fails due to the transactional nature of the test. Disabling transactions will make the test pass."


### PR DESCRIPTION
This test is the same test from ActiveRecord.

This PR just move the test to disabled transactions.