### PR TITLE
[Fix] Accounts recreate

### DIFF
--- a/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -2,8 +2,6 @@ require "cases/helper_cockroachdb"
 require "cases/helper"
 require "support/ddl_helper"
 require "support/connection_helper"
-require 'pry'
-require 'readline'
 
 module CockroachDB
   module ConnectionAdapters

--- a/test/cases/fixtures_test.rb
+++ b/test/cases/fixtures_test.rb
@@ -354,6 +354,7 @@ module CockroachDB
         t.references :firm, index: false
         t.string  :firm_name
         t.integer :credit_limit
+        t.integer "a" * max_identifier_length
       end
 
       Company.connection.drop_table :companies, if_exists: true
@@ -431,6 +432,17 @@ module CockroachDB
         instance.save!
         assert_equal max_id + 1, instance.id, "Sequence reset for #{instance.class.table_name} failed."
       end
+    end
+
+    private
+
+    def max_identifier_length
+      get_identifier.first.to_i
+    end
+
+    def get_identifier
+      connection = ActiveRecord::Base.connection
+      connection.execute("SHOW max_identifier_length").values.flatten
     end
   end
 end


### PR DESCRIPTION
This PR fixes a Cockroach test on recreation table accounts with a new column.