### PR TITLE
Update retry logic for ActiveRecord 6

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb/transaction_manager.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/transaction_manager.rb
@@ -8,16 +8,22 @@ module ActiveRecord
         # transactions that fail due to serialization errors. Failed
         # transactions will be retried until they pass or the max retry limit is
         # exceeded.
-        def within_new_transaction(options = {})
-          attempts = options.fetch(:attempts, 0)
+        def within_new_transaction(isolation: nil, joinable: true, attempts: 0)
           super
-        rescue ActiveRecord::SerializationFailure => error
+        rescue ActiveRecord::StatementInvalid => error
+          raise unless retryable? error
           raise if attempts >= @connection.max_transaction_retries
 
           attempts += 1
           sleep_seconds = (2 ** attempts + rand) / 10
           sleep(sleep_seconds)
-          within_new_transaction(options.merge(attempts: attempts)) { yield }
+          within_new_transaction(isolation: isolation, joinable: joinable, attempts: attempts) { yield }
+        end
+
+        def retryable?(error)
+          return true if error.is_a? ActiveRecord::SerializationFailure
+          return retryable? error.cause if error.cause
+          false
         end
       end
     end


### PR DESCRIPTION
Also, add a check so it only retries on SerializationFailure.

Thanks to @Cikey for the patch: https://github.com/Cikey/activerecord-cockroachdb-adapter/commit/4d0f10e471131b558232ce4ed9a2166ee7a5851d