### PR TITLE
Override test_finding_with_subquery_with_eager_loading_in_from

### DIFF
--- a/test/cases/relations_test.rb
+++ b/test/cases/relations_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+require "models/comment"
+
+class RelationTest < ActiveRecord::TestCase
+  fixtures :posts, :comments
+
+  def test_finding_with_subquery_with_eager_loading_in_from
+    relation = Comment.includes(:post).where("posts.type": "Post").order(:id)
+    assert_equal relation.to_a, Comment.select("*").from(relation).order(:id).to_a
+    assert_equal relation.to_a, Comment.select("subquery.*").from(relation).order(:id).to_a
+    assert_equal relation.to_a, Comment.select("a.*").from(relation, :a).order(:id).to_a
+  end
+end

--- a/test/excludes/RelationTest.rb
+++ b/test/excludes/RelationTest.rb
@@ -1,1 +1,2 @@
 exclude :test_finding_with_sanitized_order, "Skipping until we can triage further. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/48"
+exclude :test_finding_with_subquery_with_eager_loading_in_from, "Overridden because test depends on ordering of results."


### PR DESCRIPTION
The test relies on deterministic order of SELECT results, but did not
include an ORDER BY