### PR TITLE
Override query_conditions_for_initial_load

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb/oid/type_map_initializer.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/oid/type_map_initializer.rb
@@ -1,0 +1,26 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module CockroachDB
+      module OID
+        module TypeMapInitializer
+          # override
+          # Replaces the query with a faster version that doesn't rely on the
+          # use of 'array_in(cstring,oid,integer)'::regprocedure.
+          def query_conditions_for_initial_load
+            known_type_names = @store.keys.map { |n| "'#{n}'" }
+            known_type_types = %w('r' 'e' 'd')
+            <<~SQL % [known_type_names.join(", "), known_type_types.join(", ")]
+              WHERE
+                t.typname IN (%s)
+                OR t.typtype IN (%s)
+                OR (t.typarray = 0 AND t.typcategory='A')
+                OR t.typelem != 0
+            SQL
+          end
+        end
+
+        PostgreSQL::OID::TypeMapInitializer.prepend(TypeMapInitializer)
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -13,6 +13,7 @@ require "active_record/connection_adapters/cockroachdb/attribute_methods"
 require "active_record/connection_adapters/cockroachdb/column"
 require "active_record/connection_adapters/cockroachdb/spatial_column_info"
 require "active_record/connection_adapters/cockroachdb/setup"
+require "active_record/connection_adapters/cockroachdb/oid/type_map_initializer"
 require "active_record/connection_adapters/cockroachdb/oid/spatial"
 require "active_record/connection_adapters/cockroachdb/arel_tosql"
 

--- a/test/excludes/PostgresqlMoneyTest.rb
+++ b/test/excludes/PostgresqlMoneyTest.rb
@@ -2,6 +2,7 @@ exclude :test_column, "The money type is not implemented in CockroachDB. See htt
 exclude :test_default, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_money_values, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_money_type_cast, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
+exclude :test_money_regex_backtracking, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_schema_dumping, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_create_and_update_money, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_update_all_with_money_string, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."


### PR DESCRIPTION
cherry pick of https://github.com/cockroachdb/activerecord-cockroachdb-adapter/pull/182

---

Overrides the `TypeMapInitializer#query_conditions_for_initial_load` method to use a faster query that doesn't rely on `'array_in(cstring,oid,integer)'::regprocedure`.

That part of the condition can be replaced with 

```
t.typarray = 0 AND t.typcategory='A'
```

This can be verified by comparing the following queries:

``` 
SELECT t.oid, t.typinput, t.typarray, t.typcategory FROM
pg_type as t WHERE t.typinput='array_in(cstring,oid,integer)'::regprocedure
ORDER BY t.oid;
```

```
SELECT t.oid, t.typinput, t.typarray, t.typcategory FROM
pg_type as t WHERE t.typarray=0 AND t.typcategory='A' ORDER BY t.oid;
```
the second query is about 10x faster for me.

A potential issue is that these do not return the same results in Postgres (a few records are missing from the second) so the queries could eventually diverge depending on updates to Cockroach.

This is related to https://github.com/cockroachdb/cockroach/issues/61082.