### PR TITLE
Set supports_partitioned_indexes to false

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -216,6 +216,10 @@ module ActiveRecord
         @crdb_version >= 202
       end
 
+      def supports_partitioned_indexes?
+        false
+      end
+
       # This is hardcoded to 63 (as previously was in ActiveRecord 5.0) to aid in
       # migration from PostgreSQL to CockroachDB. In practice, this limitation
       # is arbitrary since CockroachDB supports index name lengths and table alias

--- a/test/excludes/PostgresqlMoneyTest.rb
+++ b/test/excludes/PostgresqlMoneyTest.rb
@@ -2,6 +2,7 @@ exclude :test_column, "The money type is not implemented in CockroachDB. See htt
 exclude :test_default, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_money_values, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_money_type_cast, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
+exclude :test_money_regex_backtracking, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_schema_dumping, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_create_and_update_money, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."
 exclude :test_update_all_with_money_string, "The money type is not implemented in CockroachDB. See https://github.com/cockroachdb/cockroach/issues/41578."


### PR DESCRIPTION
This was false until we bumped our advertised PostgreSQL version in
v21.1. I set it back to false since it was causing a test failure.