### PR TITLE
Allow Follower Reads on pg_type Queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ development:
   user: <username>
 ```
 
+## Configuration
+
+In addition to the standard adapter settings, CockroachDB also supports the following:
+
+- `use_follower_reads_for_type_introspection`: Use follower reads on queries to the `pg_type` catalog when set to `true`. This helps to speed up initialization by reading historical data, but may not find recently created user-defined types.
+
 ## Working with Spatial Data
 
 The adapter uses [RGeo](https://github.com/rgeo/rgeo) and [RGeo-ActiveRecord](https://github.com/rgeo/rgeo-activerecord) to represent geometric and geographic data as Ruby objects and easily interface them with the adapter. The following is a brief introduction to RGeo and tips to help setup your spatial application. More documentation about RGeo can be found in the [YARD Docs](https://rubydoc.info/github/rgeo/rgeo) and [wiki](https://github.com/rgeo/rgeo/wiki).

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -268,7 +268,6 @@ module ActiveRecord
           if @config[:encoding]
             @connection.set_client_encoding(@config[:encoding])
           end
-
           self.client_min_messages = @config[:min_messages] || "warning"
           self.schema_search_path = @config[:schema_search_path] || @config[:schema_order]
 

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -447,7 +447,7 @@ module ActiveRecord
         # Currently, querying from the pg_type catalog can be slow due to geo-partitioning
         # so this modified query uses AS OF SYSTEM TIME '-10s' to read historical data.
         def load_additional_types(oids = nil)
-          if @config[:use_follower_reads]
+          if @config[:use_follower_reads_for_type_introspection]
             initializer = OID::TypeMapInitializer.new(type_map)
 
             query = <<~SQL
@@ -480,7 +480,7 @@ module ActiveRecord
         # Currently, querying from the pg_type catalog can be slow due to geo-partitioning
         # so this modified query uses AS OF SYSTEM TIME '-10s' to read historical data.
         def add_pg_decoders
-          if @config[:use_follower_reads]
+          if @config[:use_follower_reads_for_type_introspection]
             @default_timezone = nil
             @timestamp_decoder = nil
 

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -440,6 +440,91 @@ module ActiveRecord
           false
         end
 
+        # override
+        # This method loads info about data types from the database to
+        # populate the TypeMap.
+        #
+        # Currently, querying from the pg_type catalog can be slow due to geo-partitioning
+        # so this modified query uses AS OF SYSTEM TIME '-10s' to read historical data.
+        def load_additional_types(oids = nil)
+          initializer = OID::TypeMapInitializer.new(type_map)
+
+          query = <<~SQL
+            SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
+            FROM pg_type as t
+            LEFT JOIN pg_range as r ON oid = rngtypid AS OF SYSTEM TIME '-10s'
+          SQL
+
+          if oids
+            query += "WHERE t.oid IN (%s)" % oids.join(", ")
+          else
+            query += initializer.query_conditions_for_initial_load
+          end
+
+          execute_and_clear(query, "SCHEMA", []) do |records|
+            initializer.run(records)
+          end
+
+        rescue ActiveRecord::StatementInvalid => e
+          raise e unless e.cause.is_a? PG::InvalidCatalogName
+          # use original if database is younger than 10s
+          super
+        end
+
+        # override
+        # This method maps data types to their proper decoder.
+        #
+        # Currently, querying from the pg_type catalog can be slow due to geo-partitioning
+        # so this modified query uses AS OF SYSTEM TIME '-10s' to read historical data.
+        def add_pg_decoders
+          @default_timezone = nil
+          @timestamp_decoder = nil
+
+          coders_by_name = {
+            "int2" => PG::TextDecoder::Integer,
+            "int4" => PG::TextDecoder::Integer,
+            "int8" => PG::TextDecoder::Integer,
+            "oid" => PG::TextDecoder::Integer,
+            "float4" => PG::TextDecoder::Float,
+            "float8" => PG::TextDecoder::Float,
+            "numeric" => PG::TextDecoder::Numeric,
+            "bool" => PG::TextDecoder::Boolean,
+            "timestamp" => PG::TextDecoder::TimestampUtc,
+            "timestamptz" => PG::TextDecoder::TimestampWithTimeZone,
+          }
+
+          known_coder_types = coders_by_name.keys.map { |n| quote(n) }
+          query = <<~SQL % known_coder_types.join(", ")
+            SELECT t.oid, t.typname
+            FROM pg_type as t AS OF SYSTEM TIME '-10s'
+            WHERE t.typname IN (%s)
+          SQL
+
+
+          coders = execute_and_clear(query, "SCHEMA", []) do |result|
+            result
+              .map { |row| construct_coder(row, coders_by_name[row["typname"]]) }
+              .compact
+          end
+
+          map = PG::TypeMapByOid.new
+          coders.each { |coder| map.add_coder(coder) }
+          @connection.type_map_for_results = map
+
+          @type_map_for_results = PG::TypeMapByOid.new
+          @type_map_for_results.default_type_map = map
+          @type_map_for_results.add_coder(PG::TextDecoder::Bytea.new(oid: 17, name: "bytea"))
+          @type_map_for_results.add_coder(MoneyDecoder.new(oid: 790, name: "money"))
+
+          # extract timestamp decoder for use in update_typemap_for_default_timezone
+          @timestamp_decoder = coders.find { |coder| coder.name == "timestamp" }
+          update_typemap_for_default_timezone
+        rescue ActiveRecord::StatementInvalid => e
+          raise e unless e.cause.is_a? PG::InvalidCatalogName
+          # use original if database is younger than 10s
+          super
+        end
+
         def arel_visitor
           Arel::Visitors::CockroachDB.new(self)
         end

--- a/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -15,6 +15,15 @@ module CockroachDB
         @connection_handler = ActiveRecord::Base.connection_handler
       end
 
+      def teardown
+        # use connection without follower_reads
+        database_config = { "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        ar_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        database_config.update(ar_config.configuration_hash)
+
+        ActiveRecord::Base.establish_connection(database_config)
+      end
+
       def test_database_exists_returns_false_when_the_database_does_not_exist
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         config = db_config.configuration_hash.dup

--- a/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -28,6 +28,18 @@ module CockroachDB
         assert ActiveRecord::ConnectionAdapters::CockroachDBAdapter.database_exists?(db_config.configuration_hash),
           "expected database #{db_config.database} to exist"
       end
+
+      def test_using_follower_reads_connects_properly
+        database_config = { "use_follower_reads": true, "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        ar_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        database_config.update(ar_config.configuration_hash)
+
+        ActiveRecord::Base.establish_connection(database_config)
+        conn = ActiveRecord::Base.connection
+        conn_params = conn.instance_variable_get("@config")
+
+        assert conn_params[:use_follower_reads]
+      end
     end
   end
 end

--- a/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -39,7 +39,7 @@ module CockroachDB
       end
 
       def test_using_follower_reads_connects_properly
-        database_config = { "use_follower_reads": true, "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        database_config = { "use_follower_reads_for_type_introspection": true, "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
         ar_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         database_config.update(ar_config.configuration_hash)
 
@@ -47,7 +47,7 @@ module CockroachDB
         conn = ActiveRecord::Base.connection
         conn_config = conn.instance_variable_get("@config")
 
-        assert conn_config[:use_follower_reads]
+        assert conn_config[:use_follower_reads_for_type_introspection]
       end
     end
   end

--- a/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -36,9 +36,9 @@ module CockroachDB
 
         ActiveRecord::Base.establish_connection(database_config)
         conn = ActiveRecord::Base.connection
-        conn_params = conn.instance_variable_get("@config")
+        conn_config = conn.instance_variable_get("@config")
 
-        assert conn_params[:use_follower_reads]
+        assert conn_config[:use_follower_reads]
       end
     end
   end


### PR DESCRIPTION
Allows historical queries to be used on the two initialization queries that use the `pg_type` catalog. Passing the `use_follower_reads` option to the database config hash will configure which version of the query to use.