### PR TITLE
Backport follower reads optimization and bump to 6.0.0 beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.0.0-beta.5 - 2021-04-02
+
+- Added a configuration option named `use_follower_reads_for_type_introspection`.
+  If true, it improves the speed of type introspection by allowing potentially stale
+  type metadata to be read. Defaults to false.
+
 ## 6.0.0-beta.4 - 2021-03-06
 
 - Improved connection performance by refactoring an introspection

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ development:
   user: <username>
 ```
 
+## Configuration
+
+In addition to the standard adapter settings, CockroachDB also supports the following:
+
+- `use_follower_reads_for_type_introspection`: Use follower reads on queries to the `pg_type` catalog when set to `true`. This helps to speed up initialization by reading historical data, but may not find recently created user-defined types.
+
 ## Working with Spatial Data
 
 The adapter uses [RGeo](https://github.com/rgeo/rgeo) and [RGeo-ActiveRecord](https://github.com/rgeo/rgeo-activerecord) to represent geometric and geographic data as Ruby objects and easily interface them with the adapter. The following is a brief introduction to RGeo and tips to help setup your spatial application. More documentation about RGeo can be found in the [YARD Docs](https://rubydoc.info/github/rgeo/rgeo) and [wiki](https://github.com/rgeo/rgeo/wiki).

--- a/activerecord-cockroachdb-adapter.gemspec
+++ b/activerecord-cockroachdb-adapter.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "activerecord-cockroachdb-adapter"
-  spec.version       = "6.0.0-beta.4"
+  spec.version       = "6.0.0-beta.5"
   spec.licenses      = ["Apache-2.0"]
   spec.authors       = ["Cockroach Labs"]
   spec.email         = ["cockroach-db@googlegroups.com"]

--- a/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -15,12 +15,33 @@ module CockroachDB
         @connection_handler = ActiveRecord::Base.connection_handler
       end
 
+      def teardown
+        # use connection without follower_reads
+        database_config = { "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        ar_config = ActiveRecord::Base.configurations["arunit"]
+        database_config.update(ar_config)
+
+        ActiveRecord::Base.establish_connection(database_config)
+      end
+
       def test_database_exists_returns_false_when_the_database_does_not_exist
         config = ActiveRecord::Base.configurations["arunit"]
         bad_config = config.dup
         bad_config[:database] = "non_extant_database"
         assert_not ActiveRecord::ConnectionAdapters::CockroachDBAdapter.database_exists?(bad_config),
           "expected database #{bad_config[:database]} to not exist"
+      end
+
+      def test_using_follower_reads_connects_properly
+        database_config = { "use_follower_reads_for_type_introspection": true, "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        ar_config = ActiveRecord::Base.configurations["arunit"]
+        database_config.update(ar_config)
+
+        ActiveRecord::Base.establish_connection(database_config)
+        conn = ActiveRecord::Base.connection
+        conn_config = conn.instance_variable_get("@config")
+
+        assert conn_config[:use_follower_reads_for_type_introspection]
       end
     end
   end


### PR DESCRIPTION
 Allow Follower Reads on pg_type Queries (#192) 

* Add an AS OF SYSTEM TIME clause to queries on the pg_type catalog.
* Add use_follower_reads database config option
* Reset connection after follower_reads test
* Change use_follower_reads setting to user_follower_reads_for_type_introspection and add Configuration section to README.