### PR TITLE
Call Telemetry on Connection Pool Initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 6.1.0-beta.2 - 2021-03-06
+
+- Improved connection performance by refactoring an introspection
+  that loads types.
+- Changed version numbers to semver.
+
+## 6.1.0beta1
+
+- Initial support for Rails 6.1.
+- Support for spatial functionality.

--- a/activerecord-cockroachdb-adapter.gemspec
+++ b/activerecord-cockroachdb-adapter.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "activerecord-cockroachdb-adapter"
-  spec.version       = "6.1.0beta1"
+  spec.version       = "6.1.0-beta.2"
   spec.licenses      = ["Apache-2.0"]
   spec.authors       = ["Cockroach Labs"]
   spec.email         = ["cockroach-db@googlegroups.com"]

--- a/build/config.teamcity.yml
+++ b/build/config.teamcity.yml
@@ -11,6 +11,7 @@ connections:
       user: root
       requiressl: disable
       min_messages: warning
+      disable_cockroachdb_telemetry: true
     arunit_without_prepared_statements:
       database: activerecord_unittest
       host: localhost
@@ -19,6 +20,7 @@ connections:
       requiressl: disable
       min_messages: warning
       prepared_statements: false
+      disable_cockroachdb_telemetry: true
     arunit2:
       database: activerecord_unittest2
       host: localhost
@@ -26,3 +28,4 @@ connections:
       user: root
       requiressl: disable
       min_messages: warning
+      disable_cockroachdb_telemetry: true

--- a/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -15,6 +15,15 @@ module CockroachDB
         @connection_handler = ActiveRecord::Base.connection_handler
       end
 
+      def teardown
+        # use connection without follower_reads
+        database_config = { "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        ar_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        database_config.update(ar_config.configuration_hash)
+
+        ActiveRecord::Base.establish_connection(database_config)
+      end
+
       def test_database_exists_returns_false_when_the_database_does_not_exist
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         config = db_config.configuration_hash.dup
@@ -27,6 +36,19 @@ module CockroachDB
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         assert ActiveRecord::ConnectionAdapters::CockroachDBAdapter.database_exists?(db_config.configuration_hash),
           "expected database #{db_config.database} to exist"
+      end
+
+      def test_using_telemetry_builtin_connects_properly
+        database_config = { "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        ar_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        database_config.update(ar_config.configuration_hash)
+        database_config[:disable_cockroachdb_telemetry] = false
+
+        ActiveRecord::Base.establish_connection(database_config)
+        conn = ActiveRecord::Base.connection
+        conn_config = conn.instance_variable_get("@config")
+
+        assert_equal(false, conn_config[:disable_cockroachdb_telemetry])
       end
     end
   end

--- a/test/config.yml
+++ b/test/config.yml
@@ -5,14 +5,17 @@ connections:
       host: localhost
       port: 26257
       user: root
+      disable_cockroachdb_telemetry: true
     arunit_without_prepared_statements:
       min_messages: warning
       prepared_statements: false
       host: localhost
       port: 26257
       user: root
+      disable_cockroachdb_telemetry: true
     arunit2:
       min_messages: warning
       host: localhost
       port: 26257
       user: root
+      disable_cockroachdb_telemetry: true


### PR DESCRIPTION
Similar changes to #188, but instead of making the call in connection initialization, it is done during connection pool initialization. Differences in this PR are based on the discussion in #188. 

Notes:
* We decided to remove the call from the separate thread because it was causing applications to hang on startup. 
* I've added another condition to the guard statement before the telemetry call. It checks that the adapter is "cockroachdb". This is needed because the connection pool is adapter agnostic, so other adapters in the test suite would attempt to execute this statement. This would usually just result in a `StatementInvalid` exception or something harmless, but some tests use a `FakeAdapter` that don't actually implement `connection` and would cause the test suite to crash.

If these changes look good I can fix the merge conflict and add a note about `disable_cockroachdb_telemetry` to the README.