### PR TITLE
Backport telemetry and bump to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.0.0 - 2021-04-26
+
+- Add a telemetry query on start-up. This helps the Cockroach Labs team
+  prioritize support for the adapter. It can be disabled by setting the
+  `disable_cockroachdb_telemetry` configuration option to false.
+
 ## 6.0.0-beta.5 - 2021-04-02
 
 - Added a configuration option named `use_follower_reads_for_type_introspection`.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ development:
 In addition to the standard adapter settings, CockroachDB also supports the following:
 
 - `use_follower_reads_for_type_introspection`: Use follower reads on queries to the `pg_type` catalog when set to `true`. This helps to speed up initialization by reading historical data, but may not find recently created user-defined types.
+- `disable_cockroachdb_telemetry`: Determines if a telemetry call is made to the database when the connection pool is initialized. Setting this to `true` will prevent the call from being made.
 
 ## Working with Spatial Data
 

--- a/activerecord-cockroachdb-adapter.gemspec
+++ b/activerecord-cockroachdb-adapter.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "activerecord-cockroachdb-adapter"
-  spec.version       = "6.0.0-beta.5"
+  spec.version       = "6.0.0"
   spec.licenses      = ["Apache-2.0"]
   spec.authors       = ["Cockroach Labs"]
   spec.email         = ["cockroach-db@googlegroups.com"]

--- a/build/config.teamcity.yml
+++ b/build/config.teamcity.yml
@@ -11,6 +11,7 @@ connections:
       user: root
       requiressl: disable
       min_messages: warning
+      disable_cockroachdb_telemetry: true
     arunit_without_prepared_statements:
       database: activerecord_unittest
       host: localhost
@@ -19,6 +20,7 @@ connections:
       requiressl: disable
       min_messages: warning
       prepared_statements: false
+      disable_cockroachdb_telemetry: true
     arunit2:
       database: activerecord_unittest2
       host: localhost
@@ -26,3 +28,4 @@ connections:
       user: root
       requiressl: disable
       min_messages: warning
+      disable_cockroachdb_telemetry: true

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -51,6 +51,30 @@ end
 
 module ActiveRecord
   module ConnectionAdapters
+    module CockroachDBConnectionPool
+      def initialize(spec)
+        super(spec)
+        disable_telemetry = spec.config[:disable_cockroachdb_telemetry]
+        adapter = spec.config[:adapter]
+        return if disable_telemetry || adapter != "cockroachdb"
+
+        with_connection do |conn|
+          if conn.active?
+            begin
+              query = "SELECT crdb_internal.increment_feature_counter('ActiveRecord %d.%d')"
+              conn.execute(query % [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR])
+            rescue ActiveRecord::StatementInvalid
+              # The increment_feature_counter built-in is not supported on this
+              # CockroachDB version. Ignore.
+            rescue StandardError => e
+              conn.logger.warn "Unexpected error when incrementing feature counter: #{e}"
+            end
+          end
+        end
+      end
+    end
+    ConnectionPool.prepend(CockroachDBConnectionPool)
+
     class CockroachDBAdapter < PostgreSQLAdapter
       ADAPTER_NAME = "CockroachDB".freeze
       DEFAULT_PRIMARY_KEY = "rowid"
@@ -239,6 +263,7 @@ module ActiveRecord
 
       def initialize(connection, logger, conn_params, config)
         super(connection, logger, conn_params, config)
+
         crdb_version_string = query_value("SHOW crdb_version")
         if crdb_version_string.include? "v1."
           version_num = 1

--- a/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -16,7 +16,7 @@ module CockroachDB
       end
 
       def teardown
-        # use connection without follower_reads
+        # use connection without follower_reads and telemetry
         database_config = { "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
         ar_config = ActiveRecord::Base.configurations["arunit"]
         database_config.update(ar_config)
@@ -30,6 +30,19 @@ module CockroachDB
         bad_config[:database] = "non_extant_database"
         assert_not ActiveRecord::ConnectionAdapters::CockroachDBAdapter.database_exists?(bad_config),
           "expected database #{bad_config[:database]} to not exist"
+      end
+
+      def test_using_telemetry_builtin_connects_properly
+        database_config = { "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        ar_config = ActiveRecord::Base.configurations["arunit"]
+        database_config.update(ar_config)
+        database_config[:disable_cockroachdb_telemetry] = false
+
+        ActiveRecord::Base.establish_connection(database_config)
+        conn = ActiveRecord::Base.connection
+        conn_config = conn.instance_variable_get("@config")
+
+        assert_equal(false, conn_config[:disable_cockroachdb_telemetry])
       end
 
       def test_using_follower_reads_connects_properly

--- a/test/config.yml
+++ b/test/config.yml
@@ -5,14 +5,17 @@ connections:
       host: localhost
       port: 26257
       user: root
+      disable_cockroachdb_telemetry: true
     arunit_without_prepared_statements:
       min_messages: warning
       prepared_statements: false
       host: localhost
       port: 26257
       user: root
+      disable_cockroachdb_telemetry: true
     arunit2:
       min_messages: warning
       host: localhost
       port: 26257
       user: root
+      disable_cockroachdb_telemetry: true


### PR DESCRIPTION
I backported #196 as a squashed commit and bumped the version to 6.0.0.