### PR TITLE
Do not throw exception if the db doesn't exist

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -76,6 +76,8 @@ module ActiveRecord
             end
           end
         end
+      rescue ActiveRecord::NoDatabaseError
+        # The database doesn't exist, allow activerecord to catch this itself later
       end
     end
     ConnectionPool.prepend(CockroachDBConnectionPool)


### PR DESCRIPTION
`rake db:create` is failing unless `disable_cockroachdb_telemetry` is explicitly set to `true`