### PR TITLE
Rescue from `NoDatabaseError` around telemetry call

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -63,18 +63,23 @@ module ActiveRecord
         adapter = pool_config.db_config.configuration_hash[:adapter]
         return if disable_telemetry || adapter != "cockroachdb"
 
-        with_connection do |conn|
-          if conn.active?
-            begin
-              query = "SELECT crdb_internal.increment_feature_counter('ActiveRecord %d.%d')"
-              conn.execute(query % [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR])
-            rescue ActiveRecord::StatementInvalid
-              # The increment_feature_counter built-in is not supported on this
-              # CockroachDB version. Ignore.
-            rescue StandardError => e
-              conn.logger.warn "Unexpected error when incrementing feature counter: #{e}"
+
+        begin
+          with_connection do |conn|
+            if conn.active?
+              begin
+                query = "SELECT crdb_internal.increment_feature_counter('ActiveRecord %d.%d')"
+                conn.execute(query % [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR])
+              rescue ActiveRecord::StatementInvalid
+                # The increment_feature_counter built-in is not supported on this
+                # CockroachDB version. Ignore.
+              rescue StandardError => e
+                conn.logger.warn "Unexpected error when incrementing feature counter: #{e}"
+              end
             end
           end
+        rescue ActiveRecord::NoDatabaseError
+          # Prevent failures on db creation and parallel testing.
         end
       end
     end


### PR DESCRIPTION
Fixes #204  and issues running `rake db:create`