### PR TITLE
Rescue from all StandardErrors around telemetry

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -78,7 +78,7 @@ module ActiveRecord
               end
             end
           end
-        rescue ActiveRecord::NoDatabaseError
+        rescue StandardError
           # Prevent failures on db creation and parallel testing.
         end
       end


### PR DESCRIPTION
As @Piioo pointed out, 6.1.1 did not fix the parallelized database creation issue in 6.1.1. This is because the `parallel_tests` gem has a different flow than the standard ActiveRecord parallel db creation and it created a race condition where it was possible to raise `ActiveRecord::ConnectionNotEstablished` at the telemetry call.

To fix this I changed the `rescue` condition to `StandardError` instead of `ActiveRecord::NoDatabaseError` since we can get different errors from `with_connection`.

It probably makes sense to use `StandardError` here, but this would be a good time to discuss if we want to handle this more granularly. Should we make a different condition for just `ActiveRecord::ActiveRecordError` and log that somewhere? Or does it not matter? Unfortunately, there's not much documentation on what kind of errors `with_connection` can raise, so it would be safe to assume anything under `ActiveRecordError` is "normal", while anything outside of that may indicate a bigger issue (`ArgumentError`, etc.).