### PR TITLE
5.2.x: Add telemetry call upon initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CockroachDB adapter for ActiveRecord 4 and 5. This is a lightweight extension of
 Add this line to your project's Gemfile:
 
 ```ruby
-gem 'activerecord-cockroachdb-adapter', '~> 5.2.0'
+gem 'activerecord-cockroachdb-adapter', '~> 5.2'
 ```
 
 If you're using Rails 4.x, use the `0.1.x` versions of this gem.
@@ -21,6 +21,11 @@ development:
   host: <hostname>
   user: <username>
 ```
+## Configuration
+
+In addition to the standard adapter settings, CockroachDB also supports the following:
+
+- `disable_cockroachdb_telemetry`: Determines if a telemetry call is made to the database when the connection pool is initialized. Setting this to `true` will prevent the call from being made.
 
 ## Working with Spatial Data
 

--- a/activerecord-cockroachdb-adapter.gemspec
+++ b/activerecord-cockroachdb-adapter.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "activerecord-cockroachdb-adapter"
-  spec.version       = "5.2.2"
+  spec.version       = "5.2.3"
   spec.licenses      = ["Apache-2.0"]
   spec.authors       = ["Cockroach Labs"]
   spec.email         = ["cockroach-db@googlegroups.com"]

--- a/build/config.teamcity.yml
+++ b/build/config.teamcity.yml
@@ -11,6 +11,7 @@ connections:
       user: root
       requiressl: disable
       min_messages: warning
+      disable_cockroachdb_telemetry: true
     arunit_without_prepared_statements:
       database: activerecord_unittest
       host: localhost
@@ -19,6 +20,7 @@ connections:
       requiressl: disable
       min_messages: warning
       prepared_statements: false
+      disable_cockroachdb_telemetry: true
     arunit2:
       database: activerecord_unittest2
       host: localhost
@@ -26,3 +28,4 @@ connections:
       user: root
       requiressl: disable
       min_messages: warning
+      disable_cockroachdb_telemetry: true

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -68,7 +68,7 @@ module ActiveRecord
               end
             end
           end
-        rescue ActiveRecord::NoDatabaseError
+        rescue StandardError
           # Prevent failures on db creation and parallel testing.
         end
       end

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -46,6 +46,30 @@ end
 
 module ActiveRecord
   module ConnectionAdapters
+    module CockroachDBConnectionPool
+      def initialize(pool_config)
+        super(pool_config)
+        disable_telemetry = pool_config.config[:disable_cockroachdb_telemetry]
+        adapter = pool_config.config[:adapter]
+        return if disable_telemetry || adapter != "cockroachdb"
+
+        with_connection do |conn|
+          if conn.active?
+            begin
+              query = "SELECT crdb_internal.increment_feature_counter('ActiveRecord %d.%d')"
+              conn.execute(query % [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR])
+            rescue ActiveRecord::StatementInvalid
+              # The increment_feature_counter built-in is not supported on this
+              # CockroachDB version. Ignore.
+            rescue StandardError => e
+              conn.logger.warn "Unexpected error when incrementing feature counter: #{e}"
+            end
+          end
+        end
+      end
+    end
+    ConnectionPool.prepend(CockroachDBConnectionPool)
+
     class CockroachDBAdapter < PostgreSQLAdapter
       ADAPTER_NAME = "CockroachDB".freeze
       DEFAULT_PRIMARY_KEY = "rowid"
@@ -237,6 +261,7 @@ module ActiveRecord
 
       def initialize(connection, logger, conn_params, config)
         super(connection, logger, conn_params, config)
+
         crdb_version_string = query_value("SHOW crdb_version")
         if crdb_version_string.include? "v1."
           version_num = 1
@@ -252,26 +277,6 @@ module ActiveRecord
           version_num = 202
         end
         @crdb_version = version_num
-
-        if @config[:disable_cockroachdb_telemetry]
-          return
-        end
-        Thread.new do
-          pool.with_connection do |conn|
-            if !conn.active?
-              return
-            end
-            begin
-              query = "SELECT crdb_internal.increment_feature_counter('ActiveRecord %d.%d')"
-              conn.execute(query % [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR])
-            rescue ActiveRecord::StatementInvalid
-              # The increment_feature_counter built-in is not supported on this
-              # CockroachDB version. Ignore.
-            rescue => error
-              logger.warn "Unexpected error when incrementing feature counter: #{error}"
-            end
-          end
-        end
       end
         
       private

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -252,6 +252,26 @@ module ActiveRecord
           version_num = 202
         end
         @crdb_version = version_num
+
+        if @config[:disable_cockroachdb_telemetry]
+          return
+        end
+        Thread.new do
+          pool.with_connection do |conn|
+            if !conn.active?
+              return
+            end
+            begin
+              query = "SELECT crdb_internal.increment_feature_counter('ActiveRecord %d.%d')"
+              conn.execute(query % [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR])
+            rescue ActiveRecord::StatementInvalid
+              # The increment_feature_counter built-in is not supported on this
+              # CockroachDB version. Ignore.
+            rescue => error
+              logger.warn "Unexpected error when incrementing feature counter: #{error}"
+            end
+          end
+        end
       end
         
       private

--- a/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1,0 +1,71 @@
+require "cases/helper_cockroachdb"
+require "cases/helper"
+require "support/ddl_helper"
+require "support/connection_helper"
+
+module CockroachDB
+  module ConnectionAdapters
+    class PostgreSQLAdapterTest < ActiveRecord::PostgreSQLTestCase
+      self.use_transactional_tests = false
+      include DdlHelper
+      include ConnectionHelper
+
+      def setup
+        @connection = ActiveRecord::Base.connection
+        @connection_handler = ActiveRecord::Base.connection_handler
+      end
+
+      def teardown
+        # use connection without follower_reads
+        database_config = { "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        ar_config = ActiveRecord::Base.configurations["arunit"]
+        database_config.update(ar_config)
+
+        ActiveRecord::Base.establish_connection(database_config)
+      end
+
+      def test_database_exists_returns_false_when_the_database_does_not_exist
+        db_config = ActiveRecord::Base.configurations["arunit"]
+        config = db_config.dup
+        config[:database] = "non_extant_database"
+        db_exists = begin
+                      !!ActiveRecord::Base.postgresql_connection(config)
+                    rescue ActiveRecord::ActiveRecordError => error
+                      if error.message.include?("does not exist")
+                        false
+                      else
+                        raise
+                      end
+                    end
+        assert_not db_exists, "expected database #{config[:database]} to not exist"
+      end
+
+      def test_database_exists_returns_true_when_the_database_exists
+        db_config = ActiveRecord::Base.configurations["arunit"]
+        db_exists = begin
+                      !!ActiveRecord::Base.postgresql_connection(db_config)
+                    rescue ActiveRecord::ActiveRecordError => error
+                      if error.message.include?("does not exist")
+                        false
+                      else
+                        raise
+                      end
+                    end
+        assert db_exists, "expected database #{db_config[:database]} to exist"
+      end
+
+      def test_using_telemetry_builtin_connects_properly
+        database_config = { "adapter" => "cockroachdb", "database" => "activerecord_unittest" }
+        ar_config = ActiveRecord::Base.configurations["arunit"]
+        database_config.update(ar_config)
+        database_config[:disable_cockroachdb_telemetry] = false
+
+        ActiveRecord::Base.establish_connection(database_config)
+        conn = ActiveRecord::Base.connection
+        conn_config = conn.instance_variable_get("@config")
+
+        assert_equal(false, conn_config[:disable_cockroachdb_telemetry])
+      end
+    end
+  end
+end

--- a/test/config.yml
+++ b/test/config.yml
@@ -5,14 +5,17 @@ connections:
       host: localhost
       port: 26257
       user: root
+      disable_cockroachdb_telemetry: true
     arunit_without_prepared_statements:
       min_messages: warning
       prepared_statements: false
       host: localhost
       port: 26257
       user: root
+      disable_cockroachdb_telemetry: true
     arunit2:
       min_messages: warning
       host: localhost
       port: 26257
       user: root
+      disable_cockroachdb_telemetry: true


### PR DESCRIPTION
fixes https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/169

Backports commits:
- Call telemetry built-in at initialization time
- move telemetry thread to pool initialize
- Add adapter name guard before telemetry call and make call in the current thread