### PR TITLE
handle scientific notation default values

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@
 FROM cockroachdb/example-orms-builder:20200413-1918
 
 # Native dependencies for libxml-ruby and sqlite3.
-RUN apt-get update -y && apt-get install -y \
+RUN apt-get --allow-releaseinfo-change update -y && apt-get install -y \
   libxslt-dev \
   libxml2-dev \
   libsqlite3-dev \

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -352,7 +352,8 @@ module ActiveRecord
           super ||
             extract_escaped_string_from_default(default) ||
             extract_time_from_default(default) ||
-            extract_empty_array_from_default(default)
+            extract_empty_array_from_default(default) ||
+            extract_decimal_from_default(default)
         end
 
         # Both PostgreSQL and CockroachDB use C-style string escapes under the
@@ -401,6 +402,14 @@ module ActiveRecord
           return unless supports_string_to_array_coercion?
           return unless default =~ /\AARRAY\[\]\z/
           return "{}"
+        end
+
+        # This method exists to extract the decimal defaults (e.g. scientific notation)
+        # that don't get parsed correctly
+        def extract_decimal_from_default(default)
+          Float(default).to_s
+        rescue
+          nil
         end
 
         # override

--- a/test/cases/defaults_test.rb
+++ b/test/cases/defaults_test.rb
@@ -21,4 +21,25 @@ module CockroachDB
       assert_match %r/t\.datetime\s+"modified_time_function",\s+default: -> { "now\(\)" }/, output
     end
   end
+
+  class DefaultNumbersTest < ActiveRecord::TestCase
+    class DefaultNumber < ActiveRecord::Base; end
+
+    setup do
+      @connection = ActiveRecord::Base.connection
+      @connection.create_table :default_numbers do |t|
+        t.decimal :decimal_number, precision: 32, scale: 16, default: 0
+      end
+    end
+
+    teardown do
+      @connection.drop_table :default_numbers, if_exists: true
+    end
+
+    def test_default_decimal_number_in_scientific_notation
+      record = DefaultNumber.new
+      assert_equal 0.0, record.decimal_number
+      assert_equal "0.0", record.decimal_number_before_type_cast
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/223

I couldn't find any test cases for `extract_value_from_default`. so if any test cases are needed please let me know.