### PR TITLE
Fix cluster version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.1.7 - 2022-03-01
+
+- Fix query to get the CockroachDB version so it does not require any privileges.
+
 ## 6.1.6 - 2022-02-25
 
 - Fix mixed versions of CockroachDB v21.1 and v21.2 not working.

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  COCKROACH_DB_ADAPTER_VERSION = "6.1.6"
+  COCKROACH_DB_ADAPTER_VERSION = "6.1.7"
 end


### PR DESCRIPTION
fixes https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/244

SHOW CLUSTER SETTING is only available to admins, so we need to get the
version in a different way. Unfortunately, only v22.1 has a good way for
non-admins to get this info.