### PR TITLE
Add supports_text_column_with_default test helper

### DIFF
--- a/test/cases/helper.rb
+++ b/test/cases/helper.rb
@@ -58,6 +58,15 @@ def supports_default_expression?
   end
 end
 
+def supports_text_column_with_default?
+  if current_adapter?(:Mysql2Adapter)
+    conn = ActiveRecord::Base.connection
+    conn.mariadb? && conn.database_version >= "10.2.1"
+  else
+    true
+  end
+end
+
 %w[
   supports_savepoints?
   supports_partial_index?


### PR DESCRIPTION
This was backported to Rails 6.1 in https://github.com/rails/rails/pull/40822
and the tests require it now.