### PR TITLE
Disable supports_expression_index unconditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 6.1.10 - 2022-05-06
+
+- Disable supports_expression_index regardless of CockroachDB version until
+  `ON CONFLICT expression` is supported.
+
+  See https://github.com/cockroachdb/cockroach/issues/67893.
+
 ## 6.1.9 - 2022-04-26
 
 - Fix bug where duplicate `rowid` columns would be created when loading

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -181,7 +181,10 @@ module ActiveRecord
       end
 
       def supports_expression_index?
-        @crdb_version >= 2122
+        # Expression indexes are partially supported by CockroachDB v21.2,
+        # but activerecord requires "ON CONFLICT expression" support.
+        # See https://github.com/cockroachdb/cockroach/issues/67893
+        false
       end
 
       def supports_datetime_with_precision?

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  COCKROACH_DB_ADAPTER_VERSION = "6.1.9"
+  COCKROACH_DB_ADAPTER_VERSION = "6.1.10"
 end


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/67893
fixes https://github.com/cockroachdb/cockroach/issues/80777

These can be enabled when CockroachDB supports "ON CONFLICT expression"

refs https://github.com/cockroachdb/cockroach/issues/67893