### PR TITLE
Bump readme to match latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # ActiveRecord CockroachDB Adapter
 
-CockroachDB adapter for ActiveRecord 5 and 6. This is a lightweight extension of the PostgreSQL adapter that establishes compatibility with [CockroachDB](https://github.com/cockroachdb/cockroach).
+CockroachDB adapter for ActiveRecord 5, 6, and 7. This is a lightweight extension of the PostgreSQL adapter that establishes compatibility with [CockroachDB](https://github.com/cockroachdb/cockroach).
 
 ## Installation
 
 Add this line to your project's Gemfile:
 
 ```ruby
-gem 'activerecord-cockroachdb-adapter', '~> 6.1.0'
+gem 'activerecord-cockroachdb-adapter', '~> 7.0.0'
 ```
 
 If you're using Rails 5.2, use the `5.2.x` versions of this gem.
 
 If you're using Rails 6.0, use the `6.0.x` versions of this gem.
+
+If you're using Rails 7.0, use the `7.0.x` versions of this gem.
 
 In `database.yml`, use the following adapter setting:
 


### PR DESCRIPTION
Just a quick bump to the readme to signal our new support of ActiveRecord 7 and Rails 7.