### PR TITLE
Fix default numbers test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.0.2 - 2023-05-23
+
+- Fix default numbers test to expect the correct result after
+  https://github.com/cockroachdb/cockroach/pull/102299 was merged.
+
 ## 7.0.1 - 2023-03-24
 
 - Reconnect on retryable connection errors.

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -11,7 +11,7 @@ rbenv rehash
 ruby -v
 
 # Download CockroachDB
-VERSION=v22.2.6
+VERSION=v23.1.2
 wget -qO- https://binaries.cockroachdb.com/cockroach-$VERSION.linux-amd64.tgz | tar xvz
 readonly COCKROACH=./cockroach-$VERSION.linux-amd64/cockroach
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  COCKROACH_DB_ADAPTER_VERSION = "7.0.1"
+  COCKROACH_DB_ADAPTER_VERSION = "7.0.2"
 end

--- a/test/cases/defaults_test.rb
+++ b/test/cases/defaults_test.rb
@@ -36,10 +36,10 @@ module CockroachDB
       @connection.drop_table :default_numbers, if_exists: true
     end
 
-    def test_default_decimal_number_in_scientific_notation
+    def test_default_decimal_zero_with_large_scale
       record = DefaultNumber.new
       assert_equal 0.0, record.decimal_number
-      assert_equal "0.0", record.decimal_number_before_type_cast
+      assert_equal "0.0000000000000000", record.decimal_number_before_type_cast
     end
   end
 end


### PR DESCRIPTION
This patch fixes the default numbers test to expect the correct result after https://github.com/cockroachdb/cockroach/pull/102299 was merged.