### PR TITLE
refactor(test): get rid of ARCONN env.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,14 +4,12 @@ require_relative 'test/support/paths_cockroachdb'
 require_relative 'test/support/rake_helpers'
 require_relative 'test/support/template_creator'
 
-task test: ["test:cockroachdb"]
 task default: [:test]
 
 namespace :db do
   task "create_test_template" do
     ENV['DEBUG_COCKROACHDB_ADAPTER'] = "1"
     ENV['COCKROACH_SKIP_LOAD_SCHEMA'] = "1"
-    ENV["ARCONN"] = "cockroachdb"
 
     TemplateCreator.connect
     require_relative 'test/cases/helper'
@@ -26,17 +24,9 @@ namespace :db do
   end
 end
 
-namespace :test do
-  Rake::TestTask.new("cockroachdb") do |t|
-    t.libs = ARTest::CockroachDB.test_load_paths
-    t.test_files = test_files
-    t.warning = !!ENV["WARNING"]
-    t.verbose = false
-  end
-
-  task "cockroachdb:env" do
-    ENV["ARCONN"] = "cockroachdb"
-  end
+Rake::TestTask.new do |t|
+  t.libs = ARTest::CockroachDB.test_load_paths
+  t.test_files = test_files
+  t.warning = !!ENV["WARNING"]
+  t.verbose = false
 end
-
-task 'test:cockroachdb' => 'test:cockroachdb:env'

--- a/test/config.yml
+++ b/test/config.yml
@@ -1,3 +1,4 @@
+default_connection: cockroachdb
 connections:
   cockroachdb:
     arunit:


### PR DESCRIPTION
In order to simplify testing, I am reducing branching complexity. Since we always want to work with the cockroachdb adapter, lets set it as default overall in this repository using the `test/config.yml` file accordingly.

Side note: may I have sufficient rights to open a branch on this repository?