### PR TITLE
docs: Inform about CI script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ Ruby version.
 tests similarly to TeamCity. The database is destroyed between each
 test file.)
 
+Note that the actual CI test suit is ran with [this script](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/tests/activerecord.go). And test failures are tracked [cockroach#97283](https://github.com/cockroachdb/cockroach/issues/97283)
+
 Install rbenv with ruby-build on MacOS:
 
 ```bash

--- a/test/cases/migration/foreign_key_test.rb
+++ b/test/cases/migration/foreign_key_test.rb
@@ -284,22 +284,26 @@ module ActiveRecord
 
         def test_add_foreign_key_with_prefix
           ActiveRecord::Base.table_name_prefix = "p_"
+          puts "TEMP:1A: p_ set (#{__FILE__}:#{__LINE__ - 1})"
           migration = CreateSchoolsAndClassesMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
           assert_equal 1, @connection.foreign_keys("p_classes").size
         ensure
           silence_stream($stdout) { migration.migrate(:down) }
           ActiveRecord::Base.table_name_prefix = nil
+          puts "TEMP:1B: p_ unset  (#{__FILE__}:#{__LINE__ - 1})"
         end
 
         def test_add_foreign_key_with_suffix
           ActiveRecord::Base.table_name_suffix = "_s"
+          puts "TEMP:2A: _s set (#{__FILE__}:#{__LINE__ - 1})"
           migration = CreateSchoolsAndClassesMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
           assert_equal 1, @connection.foreign_keys("classes_s").size
         ensure
           silence_stream($stdout) { migration.migrate(:down) }
           ActiveRecord::Base.table_name_suffix = nil
+          puts "TEMP:2B: _s unset (#{__FILE__}:#{__LINE__ - 1})"
         end
 
         def test_remove_foreign_key_with_if_exists_not_set


### PR DESCRIPTION
From [slack](https://cabesa.slack.com/archives/C01JBLP0CRX/p1689885055116999).

# Context

Sometimes the test suite is failing because of this kind of message:

```
TimestampsWithoutTransactionTest#test_do_not_write_timestamps_on_save_if_they_are_not_attributes = 0.18 s = E


Error:
TimestampsWithoutTransactionTest#test_do_not_write_timestamps_on_save_if_they_are_not_attributes:
RuntimeError: Wrapped undumpable exception for: ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "p_timestamp_attribute_posts_s" does not exist
```

# Reason

It seems like the error comes from the `test/cases/migration/foreign_key_test.rb` file, and mostly from the fact that either the ensure block might not execute completely correctly.

Unfortunately this theory has some flaws: the test is passing, so there is no obvious failure. Hence this PR to ensure that this is a path we should continue investigating. And some documentation that would be helpful for any maintainer of this gem. (I could split this info in a MAINTAINER.md file if you prefer @rafiss)