### PR TITLE
fix(schema): render schema name when dumping foreign keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Ongoing
 
 - Add support for [AOST](cockroachlabs.com/docs/stable/as-of-system-time) queries ([#284](https://github.com/cockroachdb/activerecord-cockroachdb-adapter/pull/284))
+- Dump schema name in foreign keys ([#289](https://github.com/cockroachdb/activerecord-cockroachdb-adapter/pull/289))
 
 ## 7.0.3 - 2023-08-23
 

--- a/bin/start-cockroachdb
+++ b/bin/start-cockroachdb
@@ -20,8 +20,6 @@ cockroach start-single-node \
 	--insecure --store=type=mem,size=0.25 --advertise-addr=localhost --pid-file "$pid_file" \
 	&> "$log_file" &
 
-cockroach_pid=$!
-
 until [[ -f "$pid_file" ]]; do
 	sleep 1
 done
@@ -43,6 +41,4 @@ CREATE DATABASE activerecord_unittest;
 CREATE DATABASE activerecord_unittest2;
 SQL
 
-tail -f "$log_file"
-
-trap "kill $cockroach_pid" EXIT
+echo "CockroachDB started. PID: $(cat "$pid_file"). log: $log_file"

--- a/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
@@ -36,16 +36,24 @@ module ActiveRecord
         # Modified version of the postgresql foreign_keys method.
         # Replaces t2.oid::regclass::text with t2.relname since this is
         # more efficient in CockroachDB.
+        # Also, CockroachDB does not append the schema name in relname,
+        # so we append it manually.
         def foreign_keys(table_name)
           scope = quoted_scope(table_name)
           fk_info = exec_query(<<~SQL, "SCHEMA")
-            SELECT t2.relname AS to_table, a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid
+            SELECT CASE
+              WHEN n2.nspname = current_schema()
+              THEN ''
+              ELSE n2.nspname || '.'
+            END || t2.relname AS to_table,
+            a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred
             FROM pg_constraint c
             JOIN pg_class t1 ON c.conrelid = t1.oid
             JOIN pg_class t2 ON c.confrelid = t2.oid
             JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
             JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
             JOIN pg_namespace t3 ON c.connamespace = t3.oid
+            JOIN pg_namespace n2 ON t2.relnamespace = n2.oid
             WHERE c.contype = 'f'
               AND t1.relname = #{scope[:name]}
               AND t3.nspname = #{scope[:schema]}
@@ -54,16 +62,19 @@ module ActiveRecord
 
           fk_info.map do |row|
             options = {
-              column: row["column"],
+              column: PostgreSQL::Utils.unquote_identifier(row["column"]),
               name: row["name"],
               primary_key: row["primary_key"]
             }
 
             options[:on_delete] = extract_foreign_key_action(row["on_delete"])
             options[:on_update] = extract_foreign_key_action(row["on_update"])
-            options[:validate] = row["valid"]
+            options[:deferrable] = extract_foreign_key_deferrable(row["deferrable"], row["deferred"])
 
-            ForeignKeyDefinition.new(table_name, row["to_table"], options)
+            options[:validate] = row["valid"]
+            to_table = PostgreSQL::Utils.unquote_identifier(row["to_table"])
+
+            ForeignKeyDefinition.new(table_name, to_table, options)
           end
         end
 


### PR DESCRIPTION
In PostgreSQL, `oid::regclass::text` renders the schema name if it is not `public`. In CockroachDB, this is not the case, so we need to append the schema name manually.