### PR TITLE
fix(test): fk always valid

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.rb]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,11 @@ module RailsTag
     def call
       req = gemspec_requirement
       "v" + all_activerecord_versions.find { req.satisfied_by?(_1) }.version
+    rescue => e
+      warn "Unable to determine Rails version. Using last used. Error: #{e.message}"
+      lockfile = File.expand_path("Gemfile.lock", __dir__)
+      File.foreach(lockfile, chomp: true).find { _1[/tag: (.*)$/] }
+      Regexp.last_match(1)
     end
 
     def gemspec_requirement

--- a/bin/console
+++ b/bin/console
@@ -12,39 +12,23 @@ require "active_record"
 #       structure_load(Post.connection_db_config, "awesome-file.sql")
 require "active_record/connection_adapters/cockroachdb/database_tasks"
 
-begin
-  retried = false
-  ActiveRecord::Base.establish_connection(
-    #Alternative version:  "cockroachdb://root@localhost:26257/ar_crdb_console"
-    adapter: "cockroachdb",
-    host: "localhost",
-    port: 26257,
-    user: "root",
-    database: "ar_crdb_console"
-  )
-  ActiveRecord::Base.connection
-rescue ActiveRecord::NoDatabaseError
-  raise if retried
-  system("cockroach sql --insecure --host=localhost:26257 --execute='create database ar_crdb_console'",
-    exception: true)
-  retried = true
-  retry
-end
+schema_kind = ENV.fetch("SCHEMA_KIND", "default")
 
-class Post < ActiveRecord::Base
-end
+system("cockroach sql --insecure --host=localhost:26257 --execute='drop database if exists ar_crdb_console'",
+  exception: true)
+system("cockroach sql --insecure --host=localhost:26257 --execute='create database ar_crdb_console'",
+  exception: true)
 
-unless Post.table_exists?
-  migration = Class.new(ActiveRecord::Migration::Current) do
-    def up
-      create_table("posts") do |t|
-        t.string :title
-        t.text :body
-      end
-    end
-  end
-  migration.migrate(:up)
-end
+ActiveRecord::Base.establish_connection(
+  #Alternative version:  "cockroachdb://root@localhost:26257/ar_crdb_console"
+  adapter: "cockroachdb",
+  host: "localhost",
+  port: 26257,
+  user: "root",
+  database: "ar_crdb_console"
+)
+
+load "#{__dir__}/console_schemas/#{schema_kind}.rb"
 
 require "irb"
 IRB.start(__FILE__)

--- a/bin/console_schemas/default.rb
+++ b/bin/console_schemas/default.rb
@@ -1,0 +1,9 @@
+class Post < ActiveRecord::Base
+end
+
+ActiveRecord::Schema.define do
+  create_table("posts") do |t|
+    t.string :title
+    t.text :body
+  end
+end

--- a/bin/console_schemas/schemas.rb
+++ b/bin/console_schemas/schemas.rb
@@ -1,0 +1,23 @@
+class Post < ActiveRecord::Base
+  self.table_name = "bar.posts"
+end
+
+class Comment < ActiveRecord::Base
+  self.table_name = "foo.comments"
+end
+
+ActiveRecord::Schema.define do
+  create_schema("foo")
+  create_schema("bar")
+  create_table("bar.posts") do |t|
+    t.string :title
+    t.text :body
+  end
+
+  create_table("foo.comments") do |t|
+    t.integer :post_id
+    t.text :body
+  end
+
+  add_foreign_key "foo.comments", "bar.posts", column: "post_id"
+end

--- a/bin/start-cockroachdb
+++ b/bin/start-cockroachdb
@@ -9,6 +9,7 @@ pid_file="$root_dir/tmp/cockroach.pid"
 log_file="$root_dir/tmp/cockroachdb.log"
 
 mkdir -p "$root_dir/tmp"
+[[ -f "$pid_file" ]] && kill -9 $(cat "$pid_file")
 rm -f "$pid_file"
 
 if ! (( ${+commands[cockroach]} )); then
@@ -41,6 +42,9 @@ ALTER DATABASE system CONFIGURE ZONE USING "gc.ttlseconds" = 600;
 
 CREATE DATABASE activerecord_unittest;
 CREATE DATABASE activerecord_unittest2;
+
+SET CLUSTER SETTING sql.defaults.experimental_alter_column_type.enabled = 'true';
+SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled = 'true';
 SQL
 
 tail -f "$log_file"

--- a/lib/active_record/connection_adapters/cockroachdb/referential_integrity.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/referential_integrity.rb
@@ -11,6 +11,14 @@ module ActiveRecord
   module ConnectionAdapters
     module CockroachDB
       module ReferentialIntegrity
+        # CockroachDB will raise a `PG::ForeignKeyViolation` when re-enabling
+        # referential integrity (e.g: adding a foreign key with invalid data
+        # raises).
+        # So foreign keys should always be valid for that matter.
+        def all_foreign_keys_valid?
+          true
+        end
+
         def disable_referential_integrity
           foreign_keys = tables.map { |table| foreign_keys(table) }.flatten
 

--- a/test/cases/helper.rb
+++ b/test/cases/helper.rb
@@ -209,10 +209,12 @@ def clean_up_connection_handler
   end
 end
 
-def load_schema
-  # silence verbose schema loading
-  original_stdout = $stdout
-  $stdout = StringIO.new
+def load_schema(shush = true)
+  if shush
+    # silence verbose schema loading
+    original_stdout = $stdout
+    $stdout = StringIO.new
+  end
 
   adapter_name = ActiveRecord::Base.connection.adapter_name.downcase
   adapter_specific_schema_file = SCHEMA_ROOT + "/#{adapter_name}_specific_schema.rb"
@@ -225,7 +227,7 @@ def load_schema
 
   ActiveRecord::FixtureSet.reset_cache
 ensure
-  $stdout = original_stdout
+  $stdout = original_stdout if shush
 end
 
 if ENV['COCKROACH_LOAD_FROM_TEMPLATE'].nil? && ENV['COCKROACH_SKIP_LOAD_SCHEMA'].nil?


### PR DESCRIPTION
This fixes the test `#test_all_foreign_keys_valid_having_foreign_keys_in_multiple_schemas`.

@rafiss this makes it that we do not need the query to validate referential integrity (see slack).