### PR TITLE
fix(test): Ensure `$stdout` is always restored

### DIFF
--- a/test/cases/schema_dumper_test.rb
+++ b/test/cases/schema_dumper_test.rb
@@ -83,7 +83,7 @@ module CockroachDB
         end
       ensure
         migration.migrate(:down)
-        # $stdout = original
+        $stdout = original
       end
 
       def test_timestamps_schema_dump_before_rails_7_with_timestamptz_setting
@@ -119,7 +119,7 @@ module CockroachDB
         end
       ensure
         migration.migrate(:down)
-        # $stdout = original
+        $stdout = original
       end
 
       def test_schema_dump_with_correct_timestamp_types_via_add_column_before_rails_7_with_timestamptz_setting
@@ -153,7 +153,7 @@ module CockroachDB
         end
       ensure
         migration.migrate(:down)
-        # $stdout = original
+        $stdout = original
       end
 
       def test_schema_dump_when_changing_datetime_type_for_an_existing_app


### PR DESCRIPTION
This fixes the `IOError` we could encounter in tests.

Found using:

```ruby
def bugmsg(header, stdout)
  bugged = begin; print; rescue IOError; "💥 "; end
  STDOUT.puts "🤞#{header.rjust(17)}: stdout=#{stdout.inspect} " \
    "#{bugged}(at #{caller_locations(2, 1).first})"
end

trace_var :$stdout, (proc { bugmsg("$stdout=", _1) })

TracePoint.trace(:a_return) do |tp|
  next unless tp.method_id == :reopen && tp.self == $stdout
  bugmsg("$stdout#reopen", $stdout)
end
```