### PR TITLE
chore(test): add github summary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,5 +52,6 @@ group :development, :test do
   gem "mocha", "~> 1.14.0"
   gem "sqlite3", "~> 1.4.4"
 
+  gem "minitest-github_action_reporter", github: "BuonOmo/minitest-github_action_reporter", require: "minitest/github_action_reporter_plugin"
   gem "minitest", "~> 5.15.0"
 end


### PR DESCRIPTION
I've been working on this little gem on my spare time, I think it would be quite useful for us! 

Here's the result (the *__Test Summary__* part): https://github.com/cockroachdb/activerecord-cockroachdb-adapter/actions/runs/6301821435