### PR TITLE
workflows: only trigger on pull_request and add a job wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,7 @@
 name: Test
 
 on:
-  # Triggers the workflow on push or pull request events.
-  push:
-    # This should disable running the workflow on tags, according to the
-    # on.<push|pull_request>.<branches|tags> GitHub Actions docs.
-    branches:
-      - "*"
+  # Triggers the workflow on pull request events.
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -18,7 +13,7 @@ on:
 
 # This allows a subsequently queued workflow run to interrupt previous runs.
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: '${{ github.workflow }} @ ${{ github.ref }}' 
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Since the name of the matrix job depends on the version, we define another job with a more stable name.
+  test_results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Test Results
+    needs: [test]
+    steps:
+      - run: |
+          result="${{ needs.test.result }}"
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Previously the action would be executed twice, once by a push event and
once by a pull_request event.

Add a wrapper job with a stable name, so it's easy to configure a
required check on it.