### PR TITLE
fix(schema_statements): add unique_rowid to pk_and_sequence_for

### DIFF
--- a/test/excludes/ActiveRecord/ConnectionAdapters/PostgreSQLAdapterTest.rb
+++ b/test/excludes/ActiveRecord/ConnectionAdapters/PostgreSQLAdapterTest.rb
@@ -17,6 +17,8 @@ exclude :test_invalid_index, "The error message differs from PostgreSQL."
 exclude :test_partial_index_on_column_named_like_keyword, "CockroachDB adds parentheses around the WHERE definition."
 exclude :test_only_check_for_insensitive_comparison_capability_once, "the DROP DOMAIN syntax is not supported by CRDB"
 
+exclude :test_pk_and_sequence_for, "The test needs a little rework since the sequence is empty in CRDB"
+exclude :test_pk_and_sequence_for_with_non_standard_primary_key, "The test needs a little rework since the sequence is empty in CRDB"
 
 plpgsql_needed = "Will be testable with CRDB 23.2, introducing PL-PGSQL"
 exclude :test_ignores_warnings_when_behaviour_ignore, plpgsql_needed


### PR DESCRIPTION
Allow to get the primary key in the default case.

This fixes two of the four failing `test_pk_and_sequence_for*`. The two still failing are:

## `test_pk_and_sequence_for_returns_nil_if_no_pk`

```ruby
      def test_pk_and_sequence_for_returns_nil_if_no_pk
        with_example_table "id integer" do
          assert_nil @connection.pk_and_sequence_for("ex") # => `["rowid", nil]`
        end
      end
```

the example table creation query:

```sql
CREATE TABLE ex(id integer)
```

The second query of `#pk_and_sequence_for` returns `["rowid", "public", nil]`. And the `SHOW CREATE TABLE ex` confirms it:

```sql
CREATE TABLE public.ex (
	id INT8 NULL,
	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
	CONSTRAINT ex_pkey PRIMARY KEY (rowid ASC)
)
```

## `test_pk_and_sequence_for_with_collision_pg_class_oid`

```sql
create table ex(id serial primary key);
create table ex2(id serial primary key);
DELETE FROM pg_depend WHERE objid = 'ex_id_seq'::regclass AND refobjid = 'ex'::regclass AND deptype = 'a';
```

Gives the error:

> user root does not have DELETE privilege on relation pg_depend

The bug is not related to the code, but just to the tests. @rafiss could we give a user this privilege ? I didn't see it skimming the doc... (`show grants` gives `f` for `is_grantable` on `pg_depend`...):

```sql
grant DELETE on pg_depend to root;
--> ERROR: invalid privilege type DELETE for virtual_table
```

---

On meta-testing. This took me longer than expected. I'm a bit unsure about the return on investment for simple tests, as manipulating AST can feel a bit tricky. I still pursued it because it seems that the gems (parser and unparser) are quite stable, and if we could use this not only in tests, that would be tremendous. We would need more guaranties though. And we'd need to verify the performances..

I was thinking about checking the hash of the method to be changed against a saved hash (which would be stored in an argument). If there is a change we warn. So:

```ruby
CopyCat.copy_methods(..., hash: "somehash") do ... end
# => WARN: the method XXX was updated, here's the new changed method: ...
#      If it is ok change the hash to "somenewhash"
```

I think this is the way to go, but there are definitely some tweaks to make it easier.