### PR TITLE
fix(#schema_names): Do not show crdb_internal schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Ongoing
 
 - Support arbitrary max identifier length ([#317](https://github.com/cockroachdb/activerecord-cockroachdb-adapter/pull/317)).
+- Fix `#schema_names` not to return `crdb_internal` ([#316](https://github.com/cockroachdb/activerecord-cockroachdb-adapter/pull/316))
 
 ## 7.1.0 - 2024-01-30
 

--- a/lib/active_record/connection_adapters/cockroachdb/database_tasks.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/database_tasks.rb
@@ -26,6 +26,7 @@ module ActiveRecord
             old_search_path = conn.schema_search_path
             conn.schema_search_path = search_path
             File.open(filename, "w") do |file|
+              # NOTE: There is no issue with the crdb_internal schema, it is ignored by SHOW CREATE.
               %w(SCHEMAS TYPES).each do |object_kind|
                 ActiveRecord::Base.connection.execute("SHOW CREATE ALL #{object_kind}").each_row { file.puts _1 }
               end
@@ -44,7 +45,7 @@ module ActiveRecord
 
                 file.puts sql
               end
-              file.puts "SET seach_path TO #{conn.schema_search_path};\n\n"
+              file.puts "SET search_path TO #{conn.schema_search_path};\n\n"
             end
           ensure
             conn.schema_search_path = old_search_path

--- a/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
@@ -4,6 +4,13 @@ module ActiveRecord
       module SchemaStatements
         include ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
 
+        # OVERRIDE: We do not want to see the crdb_internal schema in the names.
+        #
+        # Returns an array of schema names.
+        def schema_names
+          super - ["crdb_internal"]
+        end
+
         def add_index(table_name, column_name, **options)
           super
         rescue ActiveRecord::StatementInvalid => error

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rgeo/active_record"
 
 require_relative "../../arel/nodes/join_source_ext"
@@ -101,7 +103,7 @@ module ActiveRecord
     ConnectionPool.prepend(CockroachDBConnectionPool)
 
     class CockroachDBAdapter < PostgreSQLAdapter
-      ADAPTER_NAME = "CockroachDB".freeze
+      ADAPTER_NAME = "CockroachDB"
       DEFAULT_PRIMARY_KEY = "rowid"
 
       SPATIAL_COLUMN_OPTIONS =

--- a/test/cases/adapters/postgresql/schema_statements_test.rb
+++ b/test/cases/adapters/postgresql/schema_statements_test.rb
@@ -4,6 +4,10 @@ require 'cases/helper_cockroachdb'
 require 'models/building'
 
 class SchemaStatementsTest < ActiveRecord::PostgreSQLTestCase
+  def test_no_crdb_internal_in_schema_names
+    assert_not_includes Building.connection.schema_names, "crdb_internal"
+  end
+
   def test_initialize_type_map
     initialized_types = Building.connection.send(:type_map).keys
 


### PR DESCRIPTION
The `schema_names` method is used to list the schemas in the database. It should not list internal schemas.

Implementation detail: we use the less performant ruby implementation rather than rewritting the method for maintainance costs.

Fixes #314