### PR TITLE
fix: Refactor new connection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem "debug"
   gem "minitest-excludes", "~> 2.0.1"
   gem "minitest-github_action_reporter", github: "BuonOmo/minitest-github_action_reporter", require: "minitest/github_action_reporter_plugin"
+  gem "ostruct", "~> 0.6"
 
   # Gems used for tests meta-programming.
   gem "parser"


### PR DESCRIPTION
The old method was calling `AbstractAdapter#initialize` with a connection object, rather than a hash. This was then setting `@unconfigured_connection`, which in turns forced to re-run `#configure_connection` when a first query was made. This is usually OK (although unnecessary) except if `use_follower_reads_for_type_introspection` is used, since it sets AOST for a single query, which fails within a transaction.

Fixes #320