### PR TITLE
chore: backport sql dump support to 6.1.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Ongoing
+
+- Add support for sql dump in rake tasks (#273).
+- Add support for table optimize hints (#266).
+
+## 7.0.2 - 2023-05-23
+
+- Fix default numbers test to expect the correct result after
+  https://github.com/cockroachdb/cockroach/pull/102299 was merged.
+
+## 7.0.1 - 2023-03-24
+
+- Reconnect on retryable connection errors.
+
+## 7.0.0 - 2022-06-02
+
+- Add support for Active Record 7.0.3
+
+## 6.1.10 - 2022-05-06
+
+- Disable supports_expression_index regardless of CockroachDB version until
+  `ON CONFLICT expression` is supported.
+
+  See https://github.com/cockroachdb/cockroach/issues/67893.
+
+## 6.1.9 - 2022-04-26
+
+- Fix bug where duplicate `rowid` columns would be created when loading
+  a schema dump of a table that was not created with an explicit primary key.
+- Support the NOT VISIBLE syntax from CockroachDB, by using the `hidden`
+  column modifier in the Rails schema.
+
 ## 6.1.8 - 2022-03-14
 
 - Add a test helper from https://github.com/rails/rails/pull/40822
@@ -32,7 +64,7 @@
 
 ## 6.1.1 - 2021-05-14
 
-- Fix a bug where starting the driver can result in a NoDatabaseError. 
+- Fix a bug where starting the driver can result in a NoDatabaseError.
 
 ## 6.1.0 - 2021-04-26
 

--- a/lib/active_record/connection_adapters/cockroachdb/database_tasks.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/database_tasks.rb
@@ -5,7 +5,43 @@ module ActiveRecord
     module CockroachDB
       class DatabaseTasks < ActiveRecord::Tasks::PostgreSQLDatabaseTasks
         def structure_dump(filename, extra_flags=nil)
-          raise "db:structure:dump is unimplemented. See https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/2"
+          if extra_flags
+            raise "No flag supported yet, please raise an issue if needed. " \
+              "https://github.com/cockroachdb/activerecord-cockroachdb-adapter/issues/new"
+          end
+
+          case ActiveRecord::Base.dump_schemas
+          when :all, String
+            raise  "Custom schemas are not supported in CockroachDB. " \
+              "See https://github.com/cockroachdb/cockroach/issues/26443."
+          when :schema_search_path
+            if configuration_hash[:schema_search_path]
+              raise  "Custom schemas are not supported in CockroachDB. " \
+                "See https://github.com/cockroachdb/cockroach/issues/26443."
+            end
+          end
+
+          conn = ActiveRecord::Base.connection
+          File.open(filename, "w") do |file|
+            %w(SCHEMAS TYPES).each do |object_kind|
+              ActiveRecord::Base.connection.execute("SHOW CREATE ALL #{object_kind}").each_row { file.puts _1 }
+            end
+
+            ignore_tables = ActiveRecord::SchemaDumper.ignore_tables.to_set
+
+            conn.execute("SHOW CREATE ALL TABLES").each_row do |(sql)|
+              if sql.start_with?("CREATE")
+                table_name = sql[/CREATE TABLE (?:.*?\.)?\"?(.*?)[\" ]/, 1]
+                next if ignore_tables.member?(table_name)
+              elsif sql.start_with?("ALTER")
+                table_name = sql[/ALTER TABLE (?:.*?\.)?\"?(.*?)[\" ]/, 1]
+                ref_table_name = sql[/REFERENCES (?:.*?\.)?\"?(.*?)[\" ]/, 1]
+                next if ignore_tables.member?(table_name) || ignore_tables.member?(ref_table_name)
+              end
+
+              file.puts sql
+            end
+          end
         end
 
         def structure_load(filename, extra_flags=nil)

--- a/test/cases/tasks/cockroachdb_rake_test.rb
+++ b/test/cases/tasks/cockroachdb_rake_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_record/tasks/database_tasks"
+require "active_record/connection_adapters/cockroachdb/database_tasks"
+
+module ActiveRecord
+  class CockroachDBStructureDumpTest < ActiveRecord::TestCase
+    def setup
+      @configuration = {
+        "adapter"  => "cockroachdb",
+        "database" => "my-app-db"
+      }
+      @filename = "/tmp/awesome-file.sql"
+      FileUtils.touch(@filename)
+    end
+
+    def teardown
+      FileUtils.rm_f(@filename)
+    end
+
+    def test_structure_dump
+      assert_equal "", File.read(@filename)
+      File.write(@filename, "NOT TODAY\n")
+
+      config = @configuration.dup
+      config["database"] = ARTest.config["connections"]["cockroachdb"]["arunit"]["database"]
+
+      begin
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          CREATE TYPE IF NOT EXISTS status AS ENUM ('open', 'closed', 'inactive');
+        SQL
+        assert_called(
+          ActiveRecord::SchemaDumper,
+          :ignore_tables,
+          returns: ["accounts", "articles"]
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, @filename)
+
+          read = File.read(@filename)
+        end
+      ensure
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          DROP TYPE IF EXISTS status;
+        SQL
+      end
+
+      read = File.read(@filename)
+      refute read.include?("NOT TODAY"), "The dump file previous content was not overwritten"
+      assert read.include?("CREATE SCHEMA public;"), "Schemas are not dumped"
+      assert read.include?("CREATE TYPE public.status AS ENUM ('open', 'closed', 'inactive');"), "Types are not dumped"
+      assert read.include?("CREATE TABLE public.schema_migrations"), "No dump done"
+      refute read.include?("CREATE TABLE public.articles ("), "\"articles\" table should be ignored"
+      refute read.include?("CREATE TABLE public.accounts ("), "\"accounts\" table should be ignored"
+    end
+  end
+end


### PR DESCRIPTION
See issue #2 and pull request #273

@rafiss I create a 6-1-stable branch that we should merge this on. Once done, we can create a tag and push the backport with a new patch version. WDYT?