### PR TITLE
chore: add license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -199,4 +199,3 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/lib/active_record/connection_adapters/cockroachdb/arel_tosql.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/arel_tosql.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module RGeo
   module ActiveRecord
     ##

--- a/lib/active_record/connection_adapters/cockroachdb/attribute_methods.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/attribute_methods.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module CockroachDB
     module AttributeMethodsMonkeyPatch

--- a/lib/active_record/connection_adapters/cockroachdb/column.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/column.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB

--- a/lib/active_record/connection_adapters/cockroachdb/column_methods.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/column_methods.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB

--- a/lib/active_record/connection_adapters/cockroachdb/database_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/database_statements.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB

--- a/lib/active_record/connection_adapters/cockroachdb/database_tasks.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/database_tasks.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "active_record/base"
 
 module ActiveRecord

--- a/lib/active_record/connection_adapters/cockroachdb/oid/date_time.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/oid/date_time.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB

--- a/lib/active_record/connection_adapters/cockroachdb/oid/interval.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/oid/interval.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # frozen-string-literal: true
 
 require "active_support/duration"

--- a/lib/active_record/connection_adapters/cockroachdb/oid/spatial.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/oid/spatial.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB

--- a/lib/active_record/connection_adapters/cockroachdb/quoting.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/quoting.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB

--- a/lib/active_record/connection_adapters/cockroachdb/referential_integrity.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/referential_integrity.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # The PostgresSQL Adapter's ReferentialIntegrity module can disable and
 # re-enable foreign key constraints by disabling all table triggers. Since
 # triggers are not available in CockroachDB, we have to remove foreign keys and

--- a/lib/active_record/connection_adapters/cockroachdb/schema_creation.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_creation.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB
@@ -15,4 +29,3 @@ module ActiveRecord
     end
   end
 end
-

--- a/lib/active_record/connection_adapters/cockroachdb/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_dumper.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB
@@ -16,4 +30,3 @@ module ActiveRecord
     end
   end
 end
-

--- a/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/schema_statements.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB

--- a/lib/active_record/connection_adapters/cockroachdb/setup.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/setup.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord # :nodoc:
   module ConnectionAdapters # :nodoc:
     module CockroachDB  # :nodoc:

--- a/lib/active_record/connection_adapters/cockroachdb/spatial_column_info.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/spatial_column_info.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB

--- a/lib/active_record/connection_adapters/cockroachdb/table_definition.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/table_definition.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord # :nodoc:
   module ConnectionAdapters # :nodoc:
     module CockroachDB # :nodoc:

--- a/lib/active_record/connection_adapters/cockroachdb/transaction_manager.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/transaction_manager.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module ConnectionAdapters
     module CockroachDB

--- a/lib/active_record/connection_adapters/cockroachdb/type.rb
+++ b/lib/active_record/connection_adapters/cockroachdb/type.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   module Type
     module CRDBExt

--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "rgeo/active_record"
 
 require_relative "../../arel/nodes/join_source_ext"
@@ -291,7 +305,6 @@ module ActiveRecord
           m.register_type "numeric" do |_, fmod, sql_type|
             precision = extract_precision(sql_type)
             scale = extract_scale(sql_type)
-
 
             # The type for the numeric depends on the width of the field,
             # so we'll do something special here.

--- a/lib/active_record/migration/cockroachdb/compatibility.rb
+++ b/lib/active_record/migration/cockroachdb/compatibility.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require "active_record/migration"
 require "active_record/migration/compatibility"
 

--- a/lib/active_record/relation/query_methods_ext.rb
+++ b/lib/active_record/relation/query_methods_ext.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   class Relation
     module QueryMethodsExt

--- a/lib/activerecord-cockroachdb-adapter.rb
+++ b/lib/activerecord-cockroachdb-adapter.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 if defined?(Rails::Railtie)
   module ActiveRecord
     module ConnectionAdapters

--- a/lib/arel/nodes/join_source_ext.rb
+++ b/lib/arel/nodes/join_source_ext.rb
@@ -1,3 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Arel
   module Nodes
     module JoinSourceExt

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module ActiveRecord
   COCKROACH_DB_ADAPTER_VERSION = "7.1.1"
 end


### PR DESCRIPTION
Script used:

```zsh
#!/usr/bin/env zsh

# Add license headers to all Ruby files in the lib folder
for file in lib/**/*.rb; do
  if [[ -f $file ]]; then
    if ! grep -q "MIT License" $file; then
      # Remove "frozen_string_literal: true" line if it exists
      sed -i '' '/frozen_string_literal: true/d' $file
      cat <<HEADER | cat - $file > $file.new
# frozen_string_literal: true

# Copyright 2024 The Cockroach Authors.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

HEADER
      # Remove more than one new line in a row
      sed -i '' '/^$/N;/^\n$/D' $file.new
      mv $file.new $file
    fi
  fi
done
```

Since I've added some frozen_string_literal headers we still have to check for tests, but it should be fine!