### PR TITLE
fix: do not alter user comments

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -427,7 +427,7 @@ module ActiveRecord
           fields.map do |field|
             dtype = field[f_type]
             field[f_type] = crdb_fields[field[f_attname]][2].downcase if re.match(dtype)
-            field[f_comment] = crdb_fields[field[f_attname]][1]&.gsub!(/^\'|\'?$/, '')
+            field[f_comment] = crdb_fields[field[f_attname]][1]
             field[f_is_hidden] = true if crdb_fields[field[f_attname]][3]
             field
           end
@@ -455,9 +455,8 @@ module ActiveRecord
             WHERE c.table_name = #{quote(table)}#{with_schema}
           SQL
 
-          fields.reduce({}) do |a, e|
-            a[e[0]] = e
-            a
+          fields.to_h do |field|
+            [field.first, field]
           end
         end
 


### PR DESCRIPTION
We used to have a regex that removed the first and last single quotes from a comment. There is no information about this decision, nor any related test. This might have been a difference between PostgreSQL and CockroachDB.

Since tests are passing without it, and comments are not quoted, we can remove the regex. Moreover, if a comment would start or end with a single quote, this would remove that quote, which is not desirable.

Fixes #381