### PR TITLE
[7-2-stable] fix: do not alter user comments

### DIFF
--- a/lib/active_record/connection_adapters/cockroachdb_adapter.rb
+++ b/lib/active_record/connection_adapters/cockroachdb_adapter.rb
@@ -407,7 +407,7 @@ module ActiveRecord
           fields.map do |field|
             dtype = field[1]
             field[1] = crdb_fields[field[0]][2].downcase if re.match(dtype)
-            field[7] = crdb_fields[field[0]][1]&.gsub!(/^\'|\'?$/, '')
+            field[7] = crdb_fields[field[0]][1]
             field[10] = true if crdb_fields[field[0]][3]
             field
           end
@@ -438,9 +438,8 @@ module ActiveRecord
             WHERE c.table_name = #{quote(table)}#{with_schema}
           SQL
 
-          fields.reduce({}) do |a, e|
-            a[e[0]] = e
-            a
+          fields.to_h do |field|
+            [field.first, field]
           end
         end
 


### PR DESCRIPTION
We used to have a regex that removed the first and last single quotes from a comment. There is no information about this decision, nor any related test. This might have been a difference between PostgreSQL and CockroachDB.

Since tests are passing without it, and comments are not quoted, we can remove the regex. Moreover, if a comment would start or end with a single quote, this would remove that quote, which is not desirable.

Fixes #381