### PR TITLE
feat(ci): follow rails more closely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
   # Triggers the workflow on pull request events.
   pull_request:
     types: [opened, reopened, synchronize]
-
+  schedule:
+    - cron: 12 13 * * 1 # Weekly
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -19,7 +20,74 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Since the name of the matrix job depends on the version, we define another job with a more stable name.
+  orchestrate:
+    runs-on: ubuntu-latest
+    name: Prepare Tests
+    outputs:
+      supported_crdbs: ${{ steps.crdb.outputs.crdbs }}
+      latest_crdb: ${{ steps.crdb.outputs.latest }}
+    steps:
+      - id: crdb
+        name: Determine Supported CockroachDB Versions
+        shell: ruby -rcsv -rjson -rnet/http -ruri {0}
+        run: |
+          link = "https://raw.githubusercontent.com/cockroachdb/docs/7c75d7596ae144c30f341b5b337b5775088f29df/src/current/_data/versions.csv"
+
+          uri = URI.parse(link)
+          data = Net::HTTP.get(uri)
+          csv = CSV.parse(data, headers: true)
+
+          versions = csv.filter_map do |row|
+            support = row["asst_supp_exp_date"]
+            support = row["maint_supp_exp_date"] if support == "N/A"
+
+            row["major_version"] if Date.parse(support) >= Date.today
+          end
+
+          File.write(ENV["GITHUB_OUTPUT"], "crdbs=#{JSON.generate(versions)}\n", mode: ?a)
+          File.write(ENV["GITHUB_OUTPUT"], "latest=#{JSON.generate(versions.max)}\n", mode: ?a)
+
+          puts File.read(ENV["GITHUB_OUTPUT"])
+
+  test:
+    runs-on: ubuntu-latest
+    needs: orchestrate
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # https://www.cockroachlabs.com/docs/releases/release-support-policy
+        crdb: ${{ fromJSON(needs.orchestrate.outputs.supported_crdbs) }}
+        ruby: ["3.4"]
+        rails: ["8-1-stable"]
+        experimental: [false]
+        include:
+          - crdb: ${{ fromJSON(needs.orchestrate.outputs.latest_crdb) }}
+            ruby: "3.4"
+            rails: "main"
+            experimental: true
+    name: Test (crdb=${{ matrix.crdb }} ruby=${{ matrix.ruby }} rails=${{ matrix.rails }})
+    steps:
+      - name: Set Up Actions
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/test-runner
+        id: test
+        with:
+          crdb: ${{ matrix.crdb }}
+          ruby: ${{ matrix.ruby }}
+        env:
+          RAILS_TAG: ${{ matrix.rails }}
+          JSON_REPORTER: "report.json"
+      - name: Upload Report
+        if: ${{ failure() && steps.test.conclusion == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: report-${{ matrix.crdb }}-${{ matrix.ruby }}-{{ matrix.rails }}
+          path: report.json
+  # Since the name of the matrix job depends on the
+  # version, we define another job with a more stable
+  # name. We also aggregate failed tests to display
+  # in the Github Summary.
   test_results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -92,29 +160,3 @@ jobs:
           echo '```json' >>$GITHUB_STEP_SUMMARY
           jq --slurp --compact-output '.' reports/*/report.json >>$GITHUB_STEP_SUMMARY
           echo '```' >>$GITHUB_STEP_SUMMARY
-
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # https://www.cockroachlabs.com/docs/releases/release-support-policy
-        crdb: [v24.3, v25.1, v25.2, v25.3]
-        ruby: ["3.4"]
-    name: Test (crdb=${{ matrix.crdb }} ruby=${{ matrix.ruby }})
-    steps:
-      - name: Set Up Actions
-        uses: actions/checkout@v4
-      - uses: ./.github/actions/test-runner
-        id: test
-        with:
-          crdb: ${{ matrix.crdb }}
-          ruby: ${{ matrix.ruby }}
-        env:
-          JSON_REPORTER: "report.json"
-      - name: Upload Report
-        if: ${{ failure() && steps.test.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: report-${{ matrix.crdb }}-${{ matrix.ruby }}
-          path: report.json

--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -28,6 +28,7 @@ jobs:
     name: Prepare Matrix
     steps:
       - id: generate-matrix
+        name: Generate Test Matrix
         run: |
           crdb=$(jq --raw-input --compact-output 'split(" ")' <<<"${{ github.event.inputs.crdb }}")
           ruby=$(jq --raw-input --compact-output 'split(" ")' <<<"${{ github.event.inputs.ruby }}")
@@ -35,7 +36,6 @@ jobs:
           ruby_len=$(wc -w <<<"${{ github.event.inputs.ruby }}")
           (( seeds_count = ${{github.event.inputs.max}} / ( crdb_len * ruby_len ) ))
           seeds=$(shuf --input-range=1-65535 --head-count=$seeds_count | jq --slurp --compact-output)
-          echo $seeds
           echo "crdb=$crdb" >> $GITHUB_OUTPUT
           echo "ruby=$ruby" >> $GITHUB_OUTPUT
           echo "seeds=$seeds" >> $GITHUB_OUTPUT
@@ -64,7 +64,7 @@ jobs:
           ruby: ${{ matrix.ruby }}
           TESTOPTS: --fail-fast
         env:
-          JSON_REPORTER: "report.json"
+          JSON_REPORTER: 'report.json'
           SEED: ${{ matrix.seed }}
       - name: Upload Report
         if: ${{ failure() && steps.test.conclusion == 'failure' }}

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gemspec
 module RailsTag
   class << self
     def call
+      env = ENV.fetch("RAILS_TAG", "default")
+      return env if env != "default"
+
       req = gemspec_requirement
       "v" + all_activerecord_versions.find { req.satisfied_by?(_1) }.version
     rescue => e
@@ -20,7 +23,7 @@ module RailsTag
     def gemspec_requirement
       File
         .foreach(File.expand_path("activerecord-cockroachdb-adapter.gemspec", __dir__), chomp: true)
-        .find { _1[/add_dependency\s.activerecord.,\s.(.*)./] }
+        .find { _1[/add_dependency\s.activerecord.,\s["'](.*?)["']/] }
 
       Gem::Requirement.new(Regexp.last_match(1))
     end
@@ -46,7 +49,7 @@ group :development, :test do
   # We need to load the gem from git to have access to activerecord's test files.
   # You can use `path: "some/local/rails"` if you want to test the gem against
   # a specific rails codebase.
-  gem "rails", github: "rails/rails", tag: RailsTag.call
+  gem "rails", github: "rails/rails", ref: RailsTag.call
 
   # Needed for the test suite
   gem "msgpack", ">= 1.7.0"

--- a/activerecord-cockroachdb-adapter.gemspec
+++ b/activerecord-cockroachdb-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Allows the use of CockroachDB as a backend for ActiveRecord and Rails apps."
   spec.homepage      = "https://github.com/cockroachdb/activerecord-cockroachdb-adapter"
 
-  spec.add_dependency "activerecord", "~> 8.1.0"
+  spec.add_dependency "activerecord", "~> 8.1.0" unless ENV.key?("RAILS_TAG")
   spec.add_dependency "pg", "~> 1.5"
   spec.add_dependency "rgeo-activerecord", "~> 8.1.0"
 


### PR DESCRIPTION
- Add a `RAILS_TAG` environment variable to specify the Rails reference to test against.
- Update CI workflows to dynamically determine supported CockroachDB versions from the official CockroachDB docs.
- Weekly run CI.