### PR TITLE
ci: declare workflow-level contents: read on ci and flaky

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Since the name of the matrix job depends on the version, we define another job with a more stable name.
   test_results:

--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -22,6 +22,9 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   prepare-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs tests / lint only; no GitHub API writes.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.